### PR TITLE
fixes: botones y nombres de dispositivo

### DIFF
--- a/OmniMonitor/Client/Pages/CrearDataset.razor
+++ b/OmniMonitor/Client/Pages/CrearDataset.razor
@@ -109,12 +109,14 @@
                        Clearable
                        FullWidth="true"
                        Label="@Localizer["SeleccionarDispositivo"]"
-                       Class="dark-field">
+                       Class="dark-field"
+                       ToStringFunc="@(id => devices.FirstOrDefault(d => d.Id == id)?.Name ?? id.ToString())">
                 @foreach (var device in devices)
                 {
                     <MudSelectItem T="int" Value="@device.Id">@device.Name</MudSelectItem>
                 }
             </MudSelect>
+
         </div>
 
         <!-- Sensor -->

--- a/OmniMonitor/Client/Pages/Datasets.razor
+++ b/OmniMonitor/Client/Pages/Datasets.razor
@@ -37,10 +37,33 @@
                   Adornment="Adornment.Start"
                   AdornmentIcon="@Icons.Material.Filled.Search"
                   Class="flex-grow-1 mr-3" />
-    <MudButton Variant="Variant.Outlined" Color="MudBlazor.Color.Secondary" StartIcon="@Icons.Material.Filled.FilterList">
-        @Localizer["Filtros"]
+
+    <MudButton Variant="Variant.Outlined"
+               Color="MudBlazor.Color.Secondary"
+               StartIcon="@Icons.Material.Filled.FilterList"
+               Class="filter-button">
+        <span class="button-text-filter">@Localizer["Filtros"]</span>
     </MudButton>
 </MudStack>
+
+<style>
+    @@media (max-width: 768px) {
+        .button-text-filter {
+            display: none !important;
+            width: 0 !important;
+            padding: 0 !important;
+            margin: 0 !important;
+        }
+ 
+        .filter-button .mud-button-icon-start,
+        .filter-button .mud-button-icon-start svg {
+            display: flex !important;
+            align-items: center !important;
+            justify-content: center !important;
+            margin: 0 auto !important;
+        }
+    }
+</style>
 
 <MudContainer Fixed="true" Class="pl-4 pr-6">
     <MudGrid GutterSize="3">

--- a/OmniMonitor/Client/Pages/EditarDataset.razor
+++ b/OmniMonitor/Client/Pages/EditarDataset.razor
@@ -117,7 +117,8 @@ else
                        Clearable
                        FullWidth="true"
                        Label="@Localizer["SeleccionarDispositivo"]"
-                       Class="dark-field">
+                       Class="dark-field"
+                       ToStringFunc="@(id => devices.FirstOrDefault(d => d.Id == id)?.Name ?? id.ToString())">
                 @foreach (var device in devices)
                 {
                     <MudSelectItem T="int" Value="@device.Id">@device.Name</MudSelectItem>

--- a/OmniMonitor/Client/Shared/AddButton.razor
+++ b/OmniMonitor/Client/Shared/AddButton.razor
@@ -6,7 +6,7 @@
            OnClick="OnClick"
            Href="@Href"
            Disabled="@Disabled">
-    @ChildContent
+    <span class="button-text">@ChildContent</span>
 </MudButton>
 
 <style>
@@ -23,19 +23,58 @@
         transition: background-color 0.16s ease, color 0.16s ease, transform 0.12s ease;
     }
 
-        .add-button:hover {
-            background-color: color-mix(in srgb, var(--action-button) 85%, black);
-            transform: translateY(-1px) scale(1.01);
-        }
+    .add-button:hover {
+        background-color: color-mix(in srgb, var(--action-button) 85%, black);
+        transform: translateY(-1px) scale(1.01);
+    }
 
 
-        .add-button:active {
-            transform: scale(0.995);
-        }
+    .add-button:active {
+        transform: scale(0.995);
+    }
 
-        .add-button:focus {
-            outline-offset: 2px;
+    .add-button:focus {
+        outline-offset: 2px;
+    }
+
+    @@media (max-width: 768px) {
+        .add-button .button-text,
+        .add-button .mud-button-icon-end {
+            display: none !important;
+            width: 0 !important;
+            padding: 0 !important;
+            margin: 0 !important;
         }
+        .add-button.mud-button{
+            padding: 9px !important;
+        }
+        .add-button .mud-button-label {
+            width: fit-content !important;
+            min-width: 0 !important;
+            max-width: none !important;
+        }
+       
+        .add-button {
+            width: fit-content !important;
+            min-width: 0 !important;
+        }
+        .add-button .mud-button-label > * {
+            flex: 0 0 auto !important;
+            width: auto !important;
+            margin: 0 !important;
+            padding: 0 !important;
+            min-width: 0 !important;
+        }
+        .add-button .mud-button-icon-start,
+        .add-button .mud-button-icon-start svg {
+            display: flex !important;
+            align-items: center !important;
+            justify-content: center !important;
+            margin: 0 auto !important;
+        }
+    }
+
+
 </style>
 
 @code {


### PR DESCRIPTION
## Descripción

Botones de crear y filtrar datasets ahora son responsive, y al seleccionar dispositivos en crear o editar dataset aparece su nombre una vez seleccionados y no su id

## Ticket asociado

SCRUM 35

## Cómo probar

abrir datasets y ponerlo en tamaño celular, abrir crear dataset y selecionar un dispositivo del dropdown

## Checklist

- [ Sí] Código compilado sin errores
- [ ] Tests locales ejecutados y aprobados
- [Sí ] Commit y branch nombrados con ticket correspondiente
- [Sí ] PR revisado y aprobado por los reviewers necesarios
