### PR TITLE
fixes permisos

### DIFF
--- a/OmniMonitor/Server/Context/Context.cs
+++ b/OmniMonitor/Server/Context/Context.cs
@@ -189,7 +189,13 @@ namespace OmniMonitor.Server.Context
                 new Permission { Id = 44, Module = "System", Action = "ManagePermissions", Name = "System.ManagePermissions", Description = "Gestionar permisos" },
                 new Permission { Id = 45, Module = "System", Action = "ViewLogs", Name = "System.ViewLogs", Description = "Ver logs del sistema" },
                 new Permission { Id = 46, Module = "System", Action = "ViewSettings", Name = "System.ViewSettings", Description = "Ver configuración del sistema" },
-                new Permission { Id = 47, Module = "System", Action = "ManageSettings", Name = "System.ManageSettings", Description = "Gestionar configuración del sistema" }
+                new Permission { Id = 47, Module = "System", Action = "ManageSettings", Name = "System.ManageSettings", Description = "Gestionar configuración del sistema" },
+
+                // Módulo KPIs
+                new Permission { Id = 48, Module = "Kpis", Action = "View", Name = "Kpis.View", Description = "Ver KPIs" },
+                new Permission { Id = 49, Module = "Kpis", Action = "Create", Name = "Kpis.Create", Description = "Crear KPIs" },
+                new Permission { Id = 50, Module = "Kpis", Action = "Edit", Name = "Kpis.Edit", Description = "Editar KPIs" },
+                new Permission { Id = 51, Module = "Kpis", Action = "Delete", Name = "Kpis.Delete", Description = "Eliminar KPIs" }
             };
 
             builder.Entity<Permission>().HasData(permissions);

--- a/OmniMonitor/Server/Controllers/DashboardController.cs
+++ b/OmniMonitor/Server/Controllers/DashboardController.cs
@@ -304,6 +304,7 @@ namespace OmniMonitor.Server.Controllers
         /// Agrega una tarjeta (DashboardCard) a un dashboard existente.
         /// </summary>
         [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+        [RequirePermission("Dashboards.Edit")]
         [HttpPost("{id}/card")]
         [ProducesResponseType(200)]
         [ProducesResponseType(404)]
@@ -499,7 +500,6 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [AllowAnonymous]
         [HttpGet("getShare/{slug}")]
         [ProducesResponseType(typeof(ShareResponseDto), 200)]
         [ProducesResponseType(404)]
@@ -520,7 +520,6 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [AllowAnonymous]
         [HttpPost("ValidateShare/{slug}/validate")]
         [ProducesResponseType(typeof(ValidateSharePasswordResponseDto), 200)]
         [ProducesResponseType(401)]

--- a/OmniMonitor/Server/Controllers/DashboardController.cs
+++ b/OmniMonitor/Server/Controllers/DashboardController.cs
@@ -232,6 +232,7 @@ namespace OmniMonitor.Server.Controllers
         /// <response code="400">Lista de IDs inválida.</response>
         /// <response code="500">Error interno del servidor.</response>
         [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+        [RequirePermission("Dashboards.Edit")]
         [HttpPost("validate-cards")]
         [ProducesResponseType(typeof(object), 200)]
         [ProducesResponseType(400)]
@@ -436,6 +437,7 @@ namespace OmniMonitor.Server.Controllers
         /// Busca dashboards por fragmento de texto en nombre o descripción.
         /// </summary>
         [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+        [RequirePermission("Dashboards.View")]
         [HttpGet("search")]
         [ProducesResponseType(typeof(List<DashboardSummaryResponse>), 200)]
         public async Task<IActionResult> SearchDashboards([FromQuery] string query)

--- a/OmniMonitor/Server/Controllers/DatasetAMController.cs
+++ b/OmniMonitor/Server/Controllers/DatasetAMController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
+using OmniMonitor.Server.Attributes;
 using OmniMonitor.Server.Context;
 using OmniMonitor.Server.Services;
 using OmniMonitor.Shared.Dtos;
@@ -32,8 +33,8 @@ namespace OmniMonitor.Server.Controllers
         /// <summary>
         /// Crea un nuevo DatasetAM.
         /// </summary>
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpPost]
+        [RequirePermission("Datasets.Create")]
         [ProducesResponseType(typeof(DatasetAM), 201)]
         [ProducesResponseType(400)]
         [ProducesResponseType(500)]
@@ -67,8 +68,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
                 /// <summary>
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpPost("filtered")]
+        [RequirePermission("Datasets.Create")]
         [ProducesResponseType(typeof(DatasetAM), 201)]
         [ProducesResponseType(400)]
         [ProducesResponseType(500)]
@@ -176,8 +177,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpPut("with-filters/{id}")]
+        [RequirePermission("Datasets.Edit")]
         [ProducesResponseType(typeof(DatasetAM), 200)]
         [ProducesResponseType(400)]
         [ProducesResponseType(404)]
@@ -291,8 +292,8 @@ namespace OmniMonitor.Server.Controllers
         /// <summary>
         /// Obtiene todos los DatasetAM para un usuario específico.
         /// </summary>
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("GetAllDatasetAMs")]
+        [RequirePermission("Datasets.View")]
         [ProducesResponseType(typeof(List<DatasetAM>), 200)]
         [ProducesResponseType(500)]
         public async Task<ActionResult<List<DatasetAM>>> GetAllDatasetAMs()
@@ -312,8 +313,8 @@ namespace OmniMonitor.Server.Controllers
         /// <summary>
         /// Obtiene un DatasetAM específico por su ID y nombre de usuario (con lógica dinámica).
         /// </summary>
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("GetDatasetAMById")]
+        [RequirePermission("Datasets.View")]
         [ProducesResponseType(typeof(DatasetAM), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
@@ -339,8 +340,8 @@ namespace OmniMonitor.Server.Controllers
         /// <summary>
         /// Obtiene un DatasetAM específico por su ID y nombre de usuario para edición (SIN lógica dinámica).
         /// </summary>
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("GetDatasetAMByIdForEdit")]
+        [RequirePermission("Datasets.View")]
         [ProducesResponseType(typeof(DatasetAM), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
@@ -366,8 +367,8 @@ namespace OmniMonitor.Server.Controllers
         /// <summary>
         /// Actualiza un DatasetAM existente.
         /// </summary>
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpPut("{id}")]
+        [RequirePermission("Datasets.Edit")]
         [ProducesResponseType(typeof(DatasetAM), 200)]
         [ProducesResponseType(400)]
         [ProducesResponseType(404)]
@@ -411,8 +412,8 @@ namespace OmniMonitor.Server.Controllers
         /// <summary>
         /// Elimina un DatasetAM y todas sus relaciones hijas.
         /// </summary>
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpDelete("{id}")]
+        [RequirePermission("Datasets.Delete")]
         [ProducesResponseType(204)] // No Content
         [ProducesResponseType(400)]
         [ProducesResponseType(404)]

--- a/OmniMonitor/Server/Controllers/DatasetController.cs
+++ b/OmniMonitor/Server/Controllers/DatasetController.cs
@@ -72,8 +72,8 @@ namespace OmniMonitor.Server.Controllers
         /// <summary>
         /// Obtiene todos los datasets para un usuario específico.
         /// </summary>
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("user")]
+        [RequirePermission("Datasets.View")]
         [ProducesResponseType(typeof(List<DatasetIM>), 200)]
         [ProducesResponseType(500)]
         public async Task<ActionResult<List<DatasetIM>>> GetAllDatasets([FromQuery] string? search = null)
@@ -105,8 +105,8 @@ namespace OmniMonitor.Server.Controllers
         /// Identifica rápidamente a qué módulo pertenece un dataset.
         /// Retorna: "Insight Monitor", "Asset Manager", "Urban Monitor", o null si no se encuentra.
         /// </summary>
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("GetDatasetModule")]
+        [RequirePermission("Datasets.View")]
         [ProducesResponseType(typeof(string), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
@@ -133,8 +133,8 @@ namespace OmniMonitor.Server.Controllers
         /// <summary>
         /// Obtiene un dataset específico por su ID y nombre de usuario.
         /// </summary>
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("GetDataset")]
+        [RequirePermission("Datasets.View")]
         [ProducesResponseType(typeof(DatasetIM), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
@@ -183,8 +183,8 @@ namespace OmniMonitor.Server.Controllers
         /// <summary>
         /// Actualiza un dataset existente.
         /// </summary>
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpPut("{datasetId}")]
+        [RequirePermission("Datasets.Edit")]
         [ProducesResponseType(typeof(DatasetIM), 200)]
         [ProducesResponseType(400)]
         [ProducesResponseType(404)]
@@ -228,8 +228,8 @@ namespace OmniMonitor.Server.Controllers
         /// <summary>
         /// Elimina un dataset.
         /// </summary>
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpDelete("DeleteDataset")]
+        [RequirePermission("Datasets.Delete")]
         [ProducesResponseType(204)] // No Content
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
@@ -256,8 +256,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("GetSensorType")]
+        [RequirePermission("Datasets.View")]
         [ProducesResponseType(typeof(string), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]

--- a/OmniMonitor/Server/Controllers/DatasetEMController.cs
+++ b/OmniMonitor/Server/Controllers/DatasetEMController.cs
@@ -33,8 +33,8 @@ namespace OmniMonitor.Server.Controllers
         /// <summary>
         /// Crea un nuevo dataset EM.
         /// </summary>
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpPost]
+        [RequirePermission("Datasets.Create")]
         [ProducesResponseType(typeof(DatasetEM), 201)]
         [ProducesResponseType(400)]
         [ProducesResponseType(403)]
@@ -79,8 +79,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpPost("filtered")]
+        [RequirePermission("Datasets.Create")]
         [ProducesResponseType(typeof(DatasetEM), 201)]
         [ProducesResponseType(400)]
         [ProducesResponseType(500)]
@@ -169,8 +169,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpPut("with-filters/{datasetId}")]
+        [RequirePermission("Datasets.Edit")]
         [ProducesResponseType(typeof(DatasetEM), 200)]
         [ProducesResponseType(400)]
         [ProducesResponseType(404)]
@@ -264,8 +264,8 @@ namespace OmniMonitor.Server.Controllers
         /// <summary>
         /// Obtiene todos los datasets EM de un usuario.
         /// </summary>
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("GetAllDatasets")]
+        [RequirePermission("Datasets.View")]
         [ProducesResponseType(typeof(List<DatasetEM>), 200)]
         [ProducesResponseType(403)]
         [ProducesResponseType(500)]
@@ -286,8 +286,8 @@ namespace OmniMonitor.Server.Controllers
         /// <summary>
         /// Obtiene un dataset EM por su ID y nombre de usuario.
         /// </summary>
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("{datasetId}")]
+        [RequirePermission("Datasets.View")]
         [ProducesResponseType(typeof(DatasetEM), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
@@ -313,9 +313,8 @@ namespace OmniMonitor.Server.Controllers
         /// <summary>
         /// Actualiza un dataset EM existente.
         /// </summary>
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpPut("{datasetId}")]
-        //[RequirePermission("Crear Datasets EM")]
+        [RequirePermission("Datasets.Edit")]
         [ProducesResponseType(typeof(DatasetEM), 200)]
         [ProducesResponseType(400)]
         [ProducesResponseType(404)]
@@ -349,8 +348,8 @@ namespace OmniMonitor.Server.Controllers
         /// <summary>
         /// Elimina un dataset EM.
         /// </summary>
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpDelete("{datasetId}")]
+        [RequirePermission("Datasets.Delete")]
         [ProducesResponseType(204)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]

--- a/OmniMonitor/Server/Controllers/DatasetFilterController.cs
+++ b/OmniMonitor/Server/Controllers/DatasetFilterController.cs
@@ -2,11 +2,11 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OmniMonitor.Server.Context;
+using OmniMonitor.Shared.Dtos;
+using OmniMonitor.Server.Attributes;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using OmniMonitor.Shared.Dtos;
-
 
 namespace OmniMonitor.Server.Controllers
 {
@@ -31,6 +31,7 @@ namespace OmniMonitor.Server.Controllers
         }
 
         [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+        [RequirePermission("Datasets.View")]
         [HttpGet("FiltrarPorModuloYEntidad")]
         public async Task<ActionResult<List<PropiedadEntidadDto>>> FiltrarPorModuloYEntidad(string modulo, int entidadId)
         {
@@ -159,6 +160,7 @@ namespace OmniMonitor.Server.Controllers
 
     
         [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+        [RequirePermission("Datasets.View")]
         [HttpGet("GetAtributoValores")]
         public async Task<ActionResult<List<string>>> GetAtributoValores(string modulo, int entidadId, string atributo)
         {
@@ -288,6 +290,7 @@ namespace OmniMonitor.Server.Controllers
 
 
     [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+    [RequirePermission("Datasets.View")]
     [HttpPost("FiltrarDatos")]
     public async Task<ActionResult<List<object>>> FiltrarDatos([FromBody] OmniMonitor.Shared.Dtos.FiltrarDatosRequest request)
     {

--- a/OmniMonitor/Server/Controllers/DatasetUMController.cs
+++ b/OmniMonitor/Server/Controllers/DatasetUMController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
+using OmniMonitor.Server.Attributes;
 using OmniMonitor.Server.Context;
 using OmniMonitor.Server.Services;
 using OmniMonitor.Shared.Dtos;
@@ -421,8 +422,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("GetAllDataset")]
+        [RequirePermission("Datasets.View")]
         [ProducesResponseType(typeof(List<Datasets>), 200)]
         [ProducesResponseType(403)]
         [ProducesResponseType(500)]
@@ -444,8 +445,8 @@ namespace OmniMonitor.Server.Controllers
         /// <summary>
         /// Obtiene todos los datasets de todos los módulos en formato unificado desde la tabla general.
         /// </summary>
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("GetAllDatasetsDto")]
+        [RequirePermission("Datasets.View")]
         [ProducesResponseType(typeof(List<DatasetDto>), 200)]
         [ProducesResponseType(403)]
         [ProducesResponseType(500)]
@@ -554,8 +555,8 @@ namespace OmniMonitor.Server.Controllers
         /// <summary>
         /// Devuelve todos los datasets en formato DatasetDtoGenerico.
         /// </summary>
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("GetAllGenericDatasetDtos")]
+        [RequirePermission("Datasets.View")]
         [ProducesResponseType(typeof(List<DatasetDtoGenerico>), 200)]
         [ProducesResponseType(500)]
     public async Task<ActionResult<List<DatasetDtoGenerico>>> GetAllGenericDatasetDtos([FromQuery] string? search = null)
@@ -669,8 +670,8 @@ namespace OmniMonitor.Server.Controllers
         /// <summary>
         /// Obtiene todos los datasets de todos los módulos con paginación.
         /// </summary>
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("GetAllDatasetsDtoPaginated")]
+        [RequirePermission("Datasets.View")]
         [ProducesResponseType(typeof(PaginatedDatasetDto), 200)]
         [ProducesResponseType(403)]
         [ProducesResponseType(500)]

--- a/OmniMonitor/Server/Controllers/DatasetUMController.cs
+++ b/OmniMonitor/Server/Controllers/DatasetUMController.cs
@@ -289,11 +289,15 @@ namespace OmniMonitor.Server.Controllers
                 {
                     return BadRequest(ModelState);
                 }
+
+                // Obtener el dataset existente para obtener el DatasetId
                 DatasetUM? existingDataset = await _datasetUMService.GetDatasetUMByIdForEditAsync(datasetId, request.Username);
                 if (existingDataset == null)
                 {
                     return NotFound($"No se encontró el dataset con ID {datasetId} para el usuario {request.Username}.");
                 }
+
+                // Primero validar el nombre en la tabla general antes de actualizar cualquier tabla
                 await _datasetUMService.ValidateDatasetNameAsync(request.Name, request.Username, ModuleType.UrbanMonitor, existingDataset.DatasetId);
 
                 var requestDataset = new CreateDatasetRequest(request.Name, request.Username, ModuleType.UrbanMonitor);
@@ -351,9 +355,6 @@ namespace OmniMonitor.Server.Controllers
                     {
                         var allNews = await _sondaUMService.GetAllNews(username, 1, null, null, 1000);
                         var filtrados = ApiDataService.StaticFilterObjects(allNews, request.Filters);
-                        foreach (var news in filtrados)
-                        {
-                        }
                         filteredIds = filtrados.Select(n => (int)n.Id).ToList();
                         req.NewsIds = filteredIds;
                     }
@@ -361,9 +362,6 @@ namespace OmniMonitor.Server.Controllers
                     {
                         IEnumerable<object> eventos = (await _sondaUMService.GetAllEvents(username)).Cast<object>();
                         var filtrados = ApiDataService.StaticFilterObjects(eventos, request.Filters);
-                        foreach (var ev in filtrados)
-                        {
-                        }
                         filteredIds = filtrados.Select(e => (int)e.Id).ToList();
                         req.EventIds = filteredIds;
                     }
@@ -458,6 +456,7 @@ namespace OmniMonitor.Server.Controllers
                 var username = User.Identity?.Name;
 
                 var datasetDtos = new List<DatasetDto>();
+
                 var datasetsIM = await _context.Datasets
                     .Include(d => d.DatasetIM)
                     .Where(d => d.Username == username && d.TipoDataset == ModuleType.InsightMonitor)
@@ -477,6 +476,7 @@ namespace OmniMonitor.Server.Controllers
                         });
                     }
                 }
+
                 var datasetsUM = await _context.Datasets
                     .Include(d => d.DatasetUM)
                     .Where(d => d.Username == username && d.TipoDataset == ModuleType.UrbanMonitor)
@@ -496,6 +496,7 @@ namespace OmniMonitor.Server.Controllers
                         });
                     }
                 }
+
                 var datasetsAM = await _context.Datasets
                     .Include(d => d.DatasetAM)
                     .Where(d => d.Username == username && d.TipoDataset == ModuleType.AssetManager)
@@ -515,6 +516,7 @@ namespace OmniMonitor.Server.Controllers
                         });
                     }
                 }
+
                 var datasetsEM = await _context.Datasets
                     .Include(d => d.DatasetEM)
                     .Where(d => d.Username == username && d.TipoDataset == ModuleType.EventManager)
@@ -534,6 +536,7 @@ namespace OmniMonitor.Server.Controllers
                         });
                     }
                 }
+
                 if (!string.IsNullOrWhiteSpace(search))
                 {
                     string normalizedSearch = NormalizeText(search);
@@ -562,6 +565,7 @@ namespace OmniMonitor.Server.Controllers
                 var username = User.Identity?.Name;
 
                 var datasetDtos = new List<DatasetDtoGenerico>();
+
                 var datasetsIM = await _context.Datasets
                     .Include(d => d.DatasetIM)
                     .Where(d => d.Username == username && d.TipoDataset == ModuleType.InsightMonitor)
@@ -582,6 +586,7 @@ namespace OmniMonitor.Server.Controllers
                         });
                     }
                 }
+
                 var datasetsUM = await _context.Datasets
                     .Include(d => d.DatasetUM)
                     .Where(d => d.Username == username && d.TipoDataset == ModuleType.UrbanMonitor)
@@ -602,6 +607,7 @@ namespace OmniMonitor.Server.Controllers
                         });
                     }
                 }
+
                 var datasetsAM = await _context.Datasets
                     .Include(d => d.DatasetAM)
                     .Where(d => d.Username == username && d.TipoDataset == ModuleType.AssetManager)
@@ -622,6 +628,7 @@ namespace OmniMonitor.Server.Controllers
                         });
                     }
                 }
+
                 var datasetsEM = await _context.Datasets
                     .Include(d => d.DatasetEM)
                     .Where(d => d.Username == username && d.TipoDataset == ModuleType.EventManager)
@@ -642,6 +649,7 @@ namespace OmniMonitor.Server.Controllers
                         });
                     }
                 }
+
                 if (!string.IsNullOrWhiteSpace(search))
                 {
                     string normalizedSearch = NormalizeText(search);

--- a/OmniMonitor/Server/Controllers/KPIController.cs
+++ b/OmniMonitor/Server/Controllers/KPIController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
+using OmniMonitor.Server.Attributes;
 using OmniMonitor.Server.Services;
 using OmniMonitor.Shared.Dtos;
 using OmniMonitor.Shared.Dtos.AM;
@@ -32,8 +33,8 @@ namespace OmniMonitor.Server.Controllers
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpPost("")]
+        [RequirePermission("Kpis.Create")]
         [ProducesResponseType(typeof(Kpi), 200)]
         [ProducesResponseType(400)]
         [ProducesResponseType(500)]
@@ -50,10 +51,10 @@ namespace OmniMonitor.Server.Controllers
                 var username = User.Identity?.Name;
                 if (string.IsNullOrEmpty(username))
                 {
-                    return BadRequest("Token inv�lido.");
+                    return BadRequest("Token inválido.");
                 }
 
-                // Crear KPI usando el servicio, pas�ndole el username
+                // Crear KPI usando el servicio, pasándole el username
                 Kpi newKpi = await _kpiService.CreateKpiAsync(request, username);
 
                 return Ok(newKpi);
@@ -81,8 +82,8 @@ namespace OmniMonitor.Server.Controllers
         /// <param name="id">id del KPI.</param>
         /// <param name="token">Token del Usuario.</param>
         /// <returns>Devuelve el KPI.</returns>
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("{id}")]
+        [RequirePermission("Kpis.View")]
         [ProducesResponseType(typeof(KpiResponse), 200)]
         [ProducesResponseType(400)]
         [ProducesResponseType(404)]
@@ -95,14 +96,14 @@ namespace OmniMonitor.Server.Controllers
                 var username = User.Identity?.Name;
                 if (string.IsNullOrEmpty(username))
                 {
-                    return BadRequest("Token inv�lido.");
+                    return BadRequest("Token inválido.");
                 }
 
                 // Buscar KPI en la base de datos
                 KpiResponse kpi = await _kpiService.CalculateKpiValueAsync(id, username);
                 if (kpi == null)
                 {
-                    return NotFound($"No se encontr� el KPI con ID {id} para el usuario {username}.");
+                    return NotFound($"No se encontró el KPI con ID {id} para el usuario {username}.");
                 }
 
                 return Ok(kpi);
@@ -127,7 +128,7 @@ namespace OmniMonitor.Server.Controllers
                 KpiResponse kpi = await _kpiService.CalculateKpiValueAsyncSinToken(id);
                 if (kpi == null)
                 {
-                    return NotFound($"No se encontr� el KPI con ID {id}");
+                    return NotFound($"No se encontró el KPI con ID {id}");
                 }
 
                 return Ok(kpi);
@@ -139,8 +140,8 @@ namespace OmniMonitor.Server.Controllers
         }
 
         // Eliminar KPI por ID
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpDelete("{id}")]
+        [RequirePermission("Kpis.Delete")]
         [ProducesResponseType(200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(403)]
@@ -152,7 +153,7 @@ namespace OmniMonitor.Server.Controllers
                 var username = User.Identity?.Name;                  
                 if (string.IsNullOrEmpty(username))
                 {
-                    return BadRequest("Token inv�lido.");
+                    return BadRequest("Token inválido.");
                 }
 
                 await _kpiService.DeleteKpiAsync(id, username);
@@ -176,8 +177,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpPatch("{id}")]
+        [RequirePermission("Kpis.Edit")]
         [ProducesResponseType(typeof(Kpi), 200)]
         [ProducesResponseType(400)]
         [ProducesResponseType(404)]
@@ -221,8 +222,8 @@ namespace OmniMonitor.Server.Controllers
         }
 
         // Obtener todos los KPIs del usuario
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("kpis")]
+        [RequirePermission("Kpis.View")]
         [ProducesResponseType(typeof(List<KpiResponse>), 200)]
         [ProducesResponseType(400)]
         [ProducesResponseType(500)]
@@ -233,7 +234,7 @@ namespace OmniMonitor.Server.Controllers
                 var username = User.Identity?.Name;
                 if (string.IsNullOrEmpty(username))
                 {
-                    return BadRequest("Token inv�lido.");
+                    return BadRequest("Token inválido.");
                 }
 
                 List<KpiResponse> kpis = await _kpiService.CalculateAllKpisForUserAsync(username);
@@ -246,8 +247,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("metrics/{module}")]
+        [RequirePermission("Kpis.View")]
         [ProducesResponseType(typeof(List<MetricInfo>), 200)]
         [ProducesResponseType(400)]
         [ProducesResponseType(500)]
@@ -257,13 +258,13 @@ namespace OmniMonitor.Server.Controllers
             {
                 if (string.IsNullOrWhiteSpace(module))
                 {
-                    return BadRequest("Debe especificarse el m�dulo.");
+                    return BadRequest("Debe especificarse el módulo.");
                 }
 
                 List<MetricInfo> metrics = await _kpiService.GetMetricInfoListAsync(module.ToUpperInvariant());
                 if (metrics == null || metrics.Count == 0)
                 {
-                    return NotFound($"No se encontraron m�tricas para el m�dulo {module}.");
+                    return NotFound($"No se encontraron métricas para el módulo {module}.");
                 }
 
                 return Ok(metrics);
@@ -271,12 +272,12 @@ namespace OmniMonitor.Server.Controllers
             catch (Exception ex)
             {
                 _logger.LogError(ex, "GetMetricInfoByModule: unexpected error for module={Module}", module);
-                return StatusCode(500, $"Error interno al obtener m�tricas: {ex.Message}");
+                return StatusCode(500, $"Error interno al obtener métricas: {ex.Message}");
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("testDates")]
+        [RequirePermission("Kpis.View")]
         [ProducesResponseType(typeof(List<DeviceData>), 200)]
         [ProducesResponseType(500)]
         public async Task<ActionResult<List<DeviceData>>> TestGetDeviceDataByDate()
@@ -287,7 +288,7 @@ namespace OmniMonitor.Server.Controllers
                 string password = "admin";
                 int deviceId = 52726;
 
-                DateTime dateFrom = DateTime.UtcNow.AddDays(-2); // hace 2 d�a
+                DateTime dateFrom = DateTime.UtcNow.AddDays(-2); // hace 2 día
                 DateTime dateTo = DateTime.UtcNow;               // ahora
 
                 var data = await _sondaIMService.GetDeviceDataByDate(deviceId, dateFrom, dateTo, username);
@@ -304,8 +305,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("test")]
+        [RequirePermission("Kpis.View")]
         public ActionResult<Kpi> GetTestKpi()
         {
             var kpi = new Kpi
@@ -315,7 +316,7 @@ namespace OmniMonitor.Server.Controllers
                 Description = "Average temperature of last hour",
                 SourceModule = "UM",
                 DatasetId = 101,
-                Unit = "�C",
+                Unit = "°C",
                 Metric = "Average",
                 Multiplier = 1.0,
                 DefaultColor = "#00FF00"
@@ -324,8 +325,8 @@ namespace OmniMonitor.Server.Controllers
             return Ok(kpi);
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("test-response")]
+        [RequirePermission("Kpis.View")]
         public ActionResult<KpiResponse> GetTestKpiResponse()
         {
             var response = new KpiResponse
@@ -340,15 +341,15 @@ namespace OmniMonitor.Server.Controllers
             return Ok(response);
         }
 
-        // Devuelve los tipos de campos posibles para un KPI seg�n el m�dulo
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+        // Devuelve los tipos de campos posibles para un KPI según el módulo
         [HttpGet("field-types")]
+        [RequirePermission("Kpis.View")]
         [ProducesResponseType(typeof(List<string>), 200)]
         [ProducesResponseType(400)]
         public ActionResult<List<string>> GetKpiFieldTypes([FromQuery] string modulo, [FromQuery] int choice)
         {
             if (string.IsNullOrWhiteSpace(modulo))
-                return BadRequest("Debe especificar el m�dulo.");
+                return BadRequest("Debe especificar el módulo.");
 
             List<string> fieldTypes = new List<string>();
             switch (modulo.ToLower())
@@ -379,7 +380,7 @@ namespace OmniMonitor.Server.Controllers
                         fieldTypes = typeof(OmniMonitor.Shared.Dtos.UM.DatasetReducedEventUMDTO).GetProperties().Select(p => p.Name).ToList();
                     break;
                 default:
-                    fieldTypes.Add("Tipo de m�dulo no soportado");
+                    fieldTypes.Add("Tipo de módulo no soportado");
                     break;
             }
             return Ok(fieldTypes);
@@ -388,8 +389,8 @@ namespace OmniMonitor.Server.Controllers
         /// <summary>
         /// Obtiene todos los KPIs de un usuario con paginación, devolviendo solo nombre y descripción.
         /// </summary>
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("GetAllKpiDtoPaginated")]
+        [RequirePermission("Kpis.View")]
         [ProducesResponseType(typeof(KpiSimplePaginatedResponse), 200)]
         [ProducesResponseType(400)]
         [ProducesResponseType(500)]
@@ -414,8 +415,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("field-values")]
+        [RequirePermission("Kpis.View")]
         [ProducesResponseType(typeof(List<string>), 200)]
         [ProducesResponseType(400)]
         [ProducesResponseType(500)]
@@ -425,7 +426,7 @@ namespace OmniMonitor.Server.Controllers
             [FromQuery] string campo,
             [FromQuery] int choice)
         {
-            // Log: llegada de la petici�n
+            // Log: llegada de la petición
             _logger.LogInformation("GET field-values called. datasetId={DatasetId}, modulo={Modulo}, campo={Campo}, choice={Choice}", datasetId, modulo, campo, choice);
 
             try
@@ -433,13 +434,13 @@ namespace OmniMonitor.Server.Controllers
                 if (datasetId <= 0)
                 {
                     _logger.LogWarning("GetFieldValues: invalid datasetId {DatasetId}", datasetId);
-                    return BadRequest("Debe especificar un ID de dataset v�lido.");
+                    return BadRequest("Debe especificar un ID de dataset válido.");
                 }
 
                 if (string.IsNullOrWhiteSpace(modulo))
                 {
                     _logger.LogWarning("GetFieldValues: missing modulo");
-                    return BadRequest("Debe especificar el m�dulo.");
+                    return BadRequest("Debe especificar el módulo.");
                 }
 
                 if (string.IsNullOrWhiteSpace(campo))
@@ -453,7 +454,7 @@ namespace OmniMonitor.Server.Controllers
                 if (string.IsNullOrEmpty(username))
                 {
                     _logger.LogWarning("GetFieldValues: invalid token");
-                    return BadRequest("Token inv�lido.");
+                    return BadRequest("Token inválido.");
                 }
 
                 List<string> fieldValues = await _kpiService.GetFieldValuesAsync(datasetId, modulo, campo, choice, username);
@@ -461,13 +462,13 @@ namespace OmniMonitor.Server.Controllers
                 if (fieldValues == null || !fieldValues.Any())
                 {
                     _logger.LogInformation("GetFieldValues: no values found for datasetId={DatasetId}, modulo={Modulo}, campo={Campo}, choice={Choice}", datasetId, modulo, campo, choice);
-                    return Ok(new List<string>()); // Retornar lista vac�a en lugar de NotFound
+                    return Ok(new List<string>()); // Retornar lista vacía en lugar de NotFound
                 }
 
                 // Log: mostrar resumen de la respuesta
                 if (fieldValues.Count <= 20)
                 {
-                    // para respuestas peque�as loguea el contenido
+                    // para respuestas pequeñas loguea el contenido
                     _logger.LogInformation("GetFieldValues: returning {Count} values: {Values}", fieldValues.Count, string.Join(", ", fieldValues));
                 }
                 else

--- a/OmniMonitor/Server/Controllers/SondaAMController.cs
+++ b/OmniMonitor/Server/Controllers/SondaAMController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
+using OmniMonitor.Server.Attributes;
 using OmniMonitor.Shared.Dtos;
 using OmniMonitor.Shared.Dtos.AM;
 
@@ -21,8 +22,8 @@ namespace OmniMonitor.Server.Controllers
             _sondaAuthService = sondaAuthService;
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("asset/assetsBasicData")]
+        [RequirePermission("Assets.View")]
         [ProducesResponseType(typeof(List<AssetDto>), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
@@ -49,8 +50,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("asset/assets")]
+        [RequirePermission("Assets.View")]
         [ProducesResponseType(typeof(List<AssetDto>), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
@@ -79,8 +80,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("stock/{stockId}")]
+        [RequirePermission("Assets.View")]
         [ProducesResponseType(typeof(StockDto), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
@@ -103,8 +104,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("bundle")]
+        [RequirePermission("Assets.View")]
         [ProducesResponseType(typeof(List<BundleDto>), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
@@ -128,8 +129,8 @@ namespace OmniMonitor.Server.Controllers
         }
 
         // Ejemplo: Obtener un asset por ID
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("asset/{id}")]
+        [RequirePermission("Assets.View")]
         [ProducesResponseType(typeof(AssetDto), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
@@ -152,8 +153,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("stock")]
+        [RequirePermission("Assets.View")]
         [ProducesResponseType(typeof(List<StockDto>), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
@@ -181,8 +182,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("relation/asset/{assetId}")]
+        [RequirePermission("Assets.View")]
         [ProducesResponseType(typeof(List<RelatedAssetDto>), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
@@ -208,8 +209,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("bundle/bundles")]
+        [RequirePermission("Assets.View")]
         [ProducesResponseType(typeof(List<BundleDto>), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
@@ -261,8 +262,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }*/
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("eventTaskInstance/{eventTaskInstanceId}")]
+        [RequirePermission("Tasks.View")]
         [ProducesResponseType(typeof(EventTaskInstanceDto), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
@@ -285,8 +286,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("eventTaskInstances")]
+        [RequirePermission("Tasks.View")]
         [ProducesResponseType(typeof(List<EventTaskInstanceDto>), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
@@ -320,8 +321,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("eventTaskInstance/actions/{taskInstanceId}")]
+        [RequirePermission("Tasks.View")]
         [ProducesResponseType(typeof(List<EventTaskActionDto>), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
@@ -344,8 +345,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("eventTaskInstance/stock/{taskInstanceId}")]
+        [RequirePermission("Tasks.View")]
         [ProducesResponseType(typeof(List<EventTaskInstanceStockDto>), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
@@ -371,8 +372,8 @@ namespace OmniMonitor.Server.Controllers
         /// <summary>
         /// Obtiene una lista de TaskTypeDto únicos de todas las instancias de tareas para el usuario y password dados.
         /// </summary>
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("typeDtos")]
+        [RequirePermission("Tasks.View")]
         public async Task<ActionResult<List<TaskTypeDto>>> GetTypeDtos()
         {
             var username = User.Identity?.Name;
@@ -380,8 +381,8 @@ namespace OmniMonitor.Server.Controllers
             return Ok(typeDtos);
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("asset/types")]
+        [RequirePermission("Assets.View")]
         [ProducesResponseType(typeof(List<AssetTypeDto>), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]

--- a/OmniMonitor/Server/Controllers/SondaEMController.cs
+++ b/OmniMonitor/Server/Controllers/SondaEMController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
+using OmniMonitor.Server.Attributes;
 using OmniMonitor.Shared.Dtos.EM;
 
 namespace OmniMonitor.Server.Controllers
@@ -20,8 +21,8 @@ namespace OmniMonitor.Server.Controllers
             _sondaAuthService = sondaAuthService;
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("event/{eventId}")]
+        [RequirePermission("Events.View")]
         [ProducesResponseType(typeof(EventDto), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
@@ -44,8 +45,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("alert/{alertId}")]
+        [RequirePermission("Alerts.View")]
         [ProducesResponseType(typeof(AlertDto), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
@@ -68,8 +69,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("alert")]
+        [RequirePermission("Alerts.View")]
         [ProducesResponseType(typeof(List<AlertDto>), 200)]
         [ProducesResponseType(500)]
         public async Task<ActionResult<List<AlertDto>>> GetAlerts(
@@ -100,8 +101,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("alert/stored")]
+        [RequirePermission("Alerts.View")]
         [ProducesResponseType(typeof(List<AlertDto>), 200)]
         [ProducesResponseType(500)]
         public async Task<ActionResult<List<AlertDto>>> GetStoredAlerts(
@@ -131,8 +132,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("event/events")]
+        [RequirePermission("Events.View")]
         [ProducesResponseType(typeof(List<EventDto>), 200)]
         [ProducesResponseType(500)]
         public async Task<ActionResult<List<EventDto>>> GetEvents(
@@ -158,8 +159,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("eventtype/eventtypes")]
+        [RequirePermission("Events.View")]
         [ProducesResponseType(typeof(List<EventTypeDto>), 200)]
         [ProducesResponseType(500)]
         public async Task<ActionResult<List<EventTypeDto>>> GetEventTypes()
@@ -181,8 +182,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("extensions/{extensionId}")]
+        [RequirePermission("Events.View")]
         [ProducesResponseType(typeof(ExtensionDtoDup), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
@@ -205,8 +206,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("extensions")]
+        [RequirePermission("Events.View")]
         [ProducesResponseType(typeof(List<ExtensionDto>), 200)]
         [ProducesResponseType(500)]
         public async Task<ActionResult<List<ExtensionDto>>> GetExtensions(
@@ -237,8 +238,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("extensions/{extensionId}/attachedItems")]
+        [RequirePermission("Events.View")]
         [ProducesResponseType(typeof(List<AttachmentDto>), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
@@ -261,8 +262,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("Event/{eventId}/extensions")]
+        [RequirePermission("Events.View")]
         [ProducesResponseType(typeof(List<ExtensionDto>), 200)]
         [ProducesResponseType(500)]
         public async Task<ActionResult<List<ExtensionDto>>> GetextensionsByEventId(
@@ -285,8 +286,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("category")]
+        [RequirePermission("Events.View")]
         [ProducesResponseType(typeof(List<CategoryDto>), 200)]
         [ProducesResponseType(500)]
         public async Task<ActionResult<List<EventDto>>> GetCategory(
@@ -307,8 +308,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("Category/alert")]
+        [RequirePermission("Alerts.View")]
         [ProducesResponseType(typeof(List<AlertDto>), 200)]
         [ProducesResponseType(500)]
         public async Task<ActionResult<List<AlertDto>>> GetAlertsCategory(
@@ -335,8 +336,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("Category/event")]
+        [RequirePermission("Events.View")]
         [ProducesResponseType(typeof(List<EventDto>), 200)]
         [ProducesResponseType(500)]
         public async Task<ActionResult<List<EventDto>>> GetEventsByIdCategory(
@@ -358,8 +359,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("Category/{categoryId}")]
+        [RequirePermission("Events.View")]
         [ProducesResponseType(typeof(CategoryDto), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]

--- a/OmniMonitor/Server/Controllers/SondaMainController.cs
+++ b/OmniMonitor/Server/Controllers/SondaMainController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
+using OmniMonitor.Server.Attributes;
 using OmniMonitor.Shared.Dtos;
 
 namespace OmniMonitor.Server.Controllers
@@ -23,8 +24,8 @@ namespace OmniMonitor.Server.Controllers
             _sondaUMApiService = sondaUMApiService;
             _sondaAuthService = sondaAuthService;
         }
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("devices")]
+        [RequirePermission("Devices.View")]
         [ProducesResponseType(typeof(List<Device>), 200)]
         [ProducesResponseType(500)]
         public async Task<ActionResult<List<Device>>> GetSondaDevices()
@@ -41,8 +42,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("devices/{id}")]
+        [RequirePermission("Devices.View")]
         [ProducesResponseType(typeof(Device), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
@@ -65,8 +66,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("data")]
+        [RequirePermission("Sensors.View")]
         [ProducesResponseType(typeof(List<DeviceData>), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
@@ -89,8 +90,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("groups")]
+        [RequirePermission("Devices.View")]
         [ProducesResponseType(typeof(List<DeviceGroup>), 200)]
         [ProducesResponseType(500)]
         public async Task<ActionResult<List<DeviceGroup>>> GetAllDeviceGroups()
@@ -107,8 +108,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("groups/{id}")]
+        [RequirePermission("Devices.View")]
         [ProducesResponseType(typeof(DeviceGroup), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
@@ -131,8 +132,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("devices/group/{id}")]
+        [RequirePermission("Devices.View")]
         [ProducesResponseType(typeof(List<Device>), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
@@ -154,8 +155,8 @@ namespace OmniMonitor.Server.Controllers
                 return StatusCode(500, $"Error interno al obtener los dispositivos del grupo: {ex.Message}");
             }
         }
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("sources")]
+        [RequirePermission("Devices.View")]
         [ProducesResponseType(typeof(List<Source>), 200)]
         [ProducesResponseType(500)]
         public async Task<ActionResult<List<Source>>> GetAllSources()
@@ -172,8 +173,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("sources/{id}")]
+        [RequirePermission("Devices.View")]
         [ProducesResponseType(typeof(Source), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
@@ -196,8 +197,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("devices/source/{id}")]
+        [RequirePermission("Devices.View")]
         [ProducesResponseType(typeof(List<Device>), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
@@ -223,8 +224,8 @@ namespace OmniMonitor.Server.Controllers
         /// <summary>
         /// Obtiene todos los sensores únicos de los dispositivos seleccionados.
         /// </summary>
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpPost("sensors/devices")]
+        [RequirePermission("Sensors.View")]
         [ProducesResponseType(typeof(List<string>), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
@@ -276,8 +277,8 @@ namespace OmniMonitor.Server.Controllers
         /// <summary>
         /// Obtiene todos los sensores únicos de los dispositivos pertenecientes a una fuente específica.
         /// </summary>
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("sensors/source/{sourceId}")]
+        [RequirePermission("Sensors.View")]
         [ProducesResponseType(typeof(List<string>), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
@@ -318,8 +319,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("sensors/data")]
+        [RequirePermission("Sensors.View")]
         [ProducesResponseType(typeof(List<SensorData>), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
@@ -365,8 +366,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("zones")]
+        [RequirePermission("Zones.View")]
         [ProducesResponseType(typeof(List<Zone>), 200)]
         [ProducesResponseType(500)]
         public async Task<ActionResult<List<Zone>>> GetAllZones()
@@ -388,8 +389,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("zones/{id}")]
+        [RequirePermission("Zones.View")]
         [ProducesResponseType(typeof(Zone), 200)]
         [ProducesResponseType(500)]
         public async Task<ActionResult<Zone>> GetZoneById(int id)
@@ -411,8 +412,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("newsUM")]
+        [RequirePermission("Zones.View")]
         [ProducesResponseType(typeof(List<News>), 200)]
         [ProducesResponseType(500)]
         public async Task<ActionResult<List<News>>> GetAllNews(
@@ -434,8 +435,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("newsUM/{id}")]
+        [RequirePermission("Zones.View")]
         [ProducesResponseType(typeof(News), 200)]
         [ProducesResponseType(500)]
         public async Task<ActionResult<News>> GetNewsById(int id)
@@ -457,8 +458,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("zones/{id}/news")]
+        [RequirePermission("Zones.View")]
         [ProducesResponseType(typeof(List<News>), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
@@ -486,8 +487,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("events")]
+        [RequirePermission("Events.View")]
         [ProducesResponseType(typeof(List<Event>), 200)]
         [ProducesResponseType(500)]
         public async Task<ActionResult<List<Event>>> GetAllEvents()
@@ -504,8 +505,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("events/{id}")]
+        [RequirePermission("Events.View")]
         [ProducesResponseType(typeof(Event), 200)]
         [ProducesResponseType(500)]
         public async Task<ActionResult<Event>> GetEventById(int id)
@@ -527,8 +528,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("zones/{id}/events")]
+        [RequirePermission("Events.View")]
         [ProducesResponseType(typeof(List<Event>), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
@@ -551,8 +552,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("kpi/deviceCount")]
+        [RequirePermission("Devices.View")]
         [ProducesResponseType(typeof(int), 200)]
         [ProducesResponseType(500)]
         public async Task<ActionResult<int>> GetDeviceCount()
@@ -569,8 +570,8 @@ namespace OmniMonitor.Server.Controllers
             }
         }
 
-        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("kpi/dataStatus")]
+        [RequirePermission("Sensors.View")]
         [ProducesResponseType(typeof(DeviceDataStatusResponse), 200)]
         [ProducesResponseType(500)]
         public async Task<ActionResult<DeviceDataStatusResponse>> GetDataStatus()

--- a/OmniMonitor/Server/Controllers/VisualizacionController.cs
+++ b/OmniMonitor/Server/Controllers/VisualizacionController.cs
@@ -81,6 +81,7 @@ namespace OmniMonitor.Server.Controllers
         /// Obtiene todas las visualizaciones de un usuario específico con paginación.
         /// </summary>
         [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+        [RequirePermission("Visualizations.View")]
         [HttpGet("GetAllVisualizacionesPaginated")]
         [ProducesResponseType(typeof(PaginatedVisualizacionDto), 200)]
         [ProducesResponseType(400)]

--- a/OmniMonitor/Server/Controllers/VisualizacionController.cs
+++ b/OmniMonitor/Server/Controllers/VisualizacionController.cs
@@ -23,7 +23,7 @@ namespace OmniMonitor.Server.Controllers
         }
 
         /// <summary>
-        /// Crea una nueva visualización.
+        /// Crea una nueva visualizaciÃ³n.
         /// </summary>
         [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [RequirePermission("Visualizations.Create")]
@@ -42,7 +42,7 @@ namespace OmniMonitor.Server.Controllers
 
                 Visualizacion nuevaVisualizacion = await _visualizacionService.CreateVisualizacionAsync(request);
 
-                // Devuelve una respuesta 201 Created con la ubicación del nuevo recurso
+                // Devuelve una respuesta 201 Created con la ubicaciÃ³n del nuevo recurso
                 return CreatedAtAction(nameof(GetVisualizacionById), new { idVisualizacion = nuevaVisualizacion.IdVisualizacion, username = nuevaVisualizacion.Username }, nuevaVisualizacion);
             }
             catch (ArgumentException ex)
@@ -51,12 +51,12 @@ namespace OmniMonitor.Server.Controllers
             }
             catch (Exception ex)
             {
-                return StatusCode(500, $"Error interno al crear la visualización: {ex.Message}");
+                return StatusCode(500, $"Error interno al crear la visualizaciÃ³n: {ex.Message}");
             }
         }
 
         /// <summary>
-        /// Obtiene todas las visualizaciones para un usuario específico.
+        /// Obtiene todas las visualizaciones para un usuario especÃ­fico.
         /// </summary>
         [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [RequirePermission("Visualizations.View")]
@@ -78,7 +78,7 @@ namespace OmniMonitor.Server.Controllers
         }
 
         /// <summary>
-        /// Obtiene todas las visualizaciones de un usuario específico con paginación.
+        /// Obtiene todas las visualizaciones de un usuario especÃ­fico con paginaciÃ³n.
         /// </summary>
         [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("GetAllVisualizacionesPaginated")]
@@ -94,7 +94,7 @@ namespace OmniMonitor.Server.Controllers
             if (string.IsNullOrWhiteSpace(username))
                 return BadRequest("Usuario no encontrado.");
             if (page <= 0 || pageSize <= 0)
-                return BadRequest("La página y el tamaño deben ser mayores a 0.");
+                return BadRequest("La pÃ¡gina y el tamaÃ±o deben ser mayores a 0.");
             try
             {
 
@@ -123,7 +123,7 @@ namespace OmniMonitor.Server.Controllers
         }
 
         /// <summary>
-        /// Obtiene una visualización específica por su ID y nombre de usuario.
+        /// Obtiene una visualizaciÃ³n especÃ­fica por su ID y nombre de usuario.
         /// </summary>
         [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [RequirePermission("Visualizations.View")]
@@ -139,14 +139,14 @@ namespace OmniMonitor.Server.Controllers
                 Visualizacion? visualizacion = await _visualizacionService.GetVisualizacionByIdAsync(idVisualizacion, username);
                 if (visualizacion == null)
                 {
-                    return NotFound($"No se encontró la visualización con ID {idVisualizacion} para el usuario {username}.");
+                    return NotFound($"No se encontrÃ³ la visualizaciÃ³n con ID {idVisualizacion} para el usuario {username}.");
                 }
 
                 return Ok(visualizacion);
             }
             catch (Exception ex)
             {
-                return StatusCode(500, $"Error interno al obtener la visualización: {ex.Message}");
+                return StatusCode(500, $"Error interno al obtener la visualizaciÃ³n: {ex.Message}");
             }
         }
 
@@ -163,19 +163,19 @@ namespace OmniMonitor.Server.Controllers
                 Visualizacion? visualizacion = await _visualizacionService.GetVisualizacionByIdAsyncSinToken(idVisualizacion);
                 if (visualizacion == null)
                 {
-                    return NotFound($"No se encontró la visualización con ID {idVisualizacion}");
+                    return NotFound($"No se encontrÃ³ la visualizaciÃ³n con ID {idVisualizacion}");
                 }
 
                 return Ok(visualizacion);
             }
             catch (Exception ex)
             {
-                return StatusCode(500, $"Error interno al obtener la visualización: {ex.Message}");
+                return StatusCode(500, $"Error interno al obtener la visualizaciÃ³n: {ex.Message}");
             }
         }
 
         /// <summary>
-        /// Elimina una visualización por su ID.
+        /// Elimina una visualizaciÃ³n por su ID.
         /// </summary>
         [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [RequirePermission("Visualizations.Delete")]
@@ -190,7 +190,7 @@ namespace OmniMonitor.Server.Controllers
                 var username = User.Identity?.Name;
                 if (string.IsNullOrEmpty(username))
                 {
-                    return Unauthorized("Token inválido o usuario no encontrado.");
+                    return Unauthorized("Token invÃ¡lido o usuario no encontrado.");
                 }
 
                 using (IServiceScope scope = HttpContext.RequestServices.CreateScope())
@@ -201,7 +201,7 @@ namespace OmniMonitor.Server.Controllers
                         .FirstOrDefaultAsync(v => v.IdVisualizacion == idVisualizacion);
                     if (visualizacion == null)
                     {
-                        return NotFound($"No se encontró la visualización con ID {idVisualizacion}.");
+                        return NotFound($"No se encontrÃ³ la visualizaciÃ³n con ID {idVisualizacion}.");
                     }
 
                     // Eliminar todos los GrupoVisualizacion asociados
@@ -218,12 +218,12 @@ namespace OmniMonitor.Server.Controllers
             }
             catch (Exception ex)
             {
-                return StatusCode(500, $"Error interno al eliminar la visualización: {ex.Message}");
+                return StatusCode(500, $"Error interno al eliminar la visualizaciÃ³n: {ex.Message}");
             }
         }
 
         /// <summary>
-        /// Edita una visualización existente por su ID.
+        /// Edita una visualizaciÃ³n existente por su ID.
         /// </summary>
         [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [RequirePermission("Visualizations.Edit")]
@@ -239,7 +239,7 @@ namespace OmniMonitor.Server.Controllers
                 var username = User.Identity?.Name;
                 if (string.IsNullOrEmpty(username))
                 {
-                    return Unauthorized("Token inválido o usuario no encontrado.");
+                    return Unauthorized("Token invÃ¡lido o usuario no encontrado.");
                 }
 
                 if (!ModelState.IsValid)
@@ -254,15 +254,15 @@ namespace OmniMonitor.Server.Controllers
                     .FirstOrDefaultAsync(v => v.IdVisualizacion == idVisualizacion);
                 if (visualizacion == null)
                 {
-                    return NotFound($"No se encontró la visualización con ID {idVisualizacion}.");
+                    return NotFound($"No se encontrÃ³ la visualizaciÃ³n con ID {idVisualizacion}.");
                 }
 
-                // Validar nombre único (excepto la propia visualización)
+                // Validar nombre Ãºnico (excepto la propia visualizaciÃ³n)
                 bool nombreDuplicado = await db.Visualizaciones
                     .AnyAsync(v => v.IdVisualizacion != idVisualizacion && v.Nombre == request.Nombre);
                 if (nombreDuplicado)
                 {
-                    return BadRequest($"Ya existe otra visualización con el nombre '{request.Nombre}'.");
+                    return BadRequest($"Ya existe otra visualizaciÃ³n con el nombre '{request.Nombre}'.");
                 }
 
                 // Validar fechas
@@ -273,14 +273,14 @@ namespace OmniMonitor.Server.Controllers
 
                 if (request.FechaDesde == default || request.FechaHasta == default)
                 {
-                    return BadRequest("Las fechas de inicio y fin deben ser válidas.");
+                    return BadRequest("Las fechas de inicio y fin deben ser vÃ¡lidas.");
                 }
 
                 // Actualizar campos principales
                 visualizacion.Nombre = request.Nombre;
                 visualizacion.FechaDesde = request.FechaDesde;
                 visualizacion.FechaHasta = request.FechaHasta;
-                visualizacion.JsonDesign = request.JsonDiseñoGeneral;
+                visualizacion.JsonDesign = request.JsonDiseÃ±oGeneral;
 
                 // --- Sincronizar GrupoDatasets ---
                 var requestDatasetIds = request.Datasets.Select(ds => ds.DatasetId).ToHashSet();
@@ -290,7 +290,7 @@ namespace OmniMonitor.Server.Controllers
                     db.GrupoDatasets.Remove(gd);
                 }
 
-                // Actualizar o agregar los que están en el request
+                // Actualizar o agregar los que estÃ¡n en el request
                 foreach (DatasetConfig ds in request.Datasets)
                 {
                     // Validar que el dataset exista en la tabla DatasetIM
@@ -304,14 +304,14 @@ namespace OmniMonitor.Server.Controllers
                     GrupoDataset? existing = visualizacion.GrupoDatasets.FirstOrDefault(gd => gd.DatasetId == ds.DatasetId);
                     if (existing != null)
                     {
-                        existing.JsonDesign = ds.JsonDiseño;
+                        existing.JsonDesign = ds.JsonDiseÃ±o;
                     }
                     else
                     {
                         visualizacion.GrupoDatasets.Add(new GrupoDataset
                         {
                             DatasetId = ds.DatasetId,
-                            JsonDesign = ds.JsonDiseño,
+                            JsonDesign = ds.JsonDiseÃ±o,
                         });
                     }
                 }
@@ -321,11 +321,12 @@ namespace OmniMonitor.Server.Controllers
             }
             catch (Exception ex)
             {
-                return StatusCode(500, $"Error interno al editar la visualización: {ex.Message}");
+                return StatusCode(500, $"Error interno al editar la visualizaciÃ³n: {ex.Message}");
             }
         }
 
         [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+        [RequirePermission("Visualizations.View")]
         [HttpPost("visualization-data")]
         [ProducesResponseType(typeof(VisualizationResponse), 200)]
         [ProducesResponseType(400)]
@@ -343,7 +344,7 @@ namespace OmniMonitor.Server.Controllers
             }
             catch (Exception ex)
             {
-                return StatusCode(500, $"Error interno al generar los datos de visualización: {ex.Message}");
+                return StatusCode(500, $"Error interno al generar los datos de visualizaciÃ³n: {ex.Message}");
             }
         }
 
@@ -365,7 +366,7 @@ namespace OmniMonitor.Server.Controllers
             }
             catch (Exception ex)
             {
-                return StatusCode(500, $"Error interno al generar los datos de visualización: {ex.Message}");
+                return StatusCode(500, $"Error interno al generar los datos de visualizaciÃ³n: {ex.Message}");
             }
         }
 

--- a/OmniMonitor/Server/Program.cs
+++ b/OmniMonitor/Server/Program.cs
@@ -126,6 +126,12 @@ builder.Services.AddAuthorization(options =>
     options.AddPolicy("Visualizations.Edit", policy => policy.Requirements.Add(new PermissionRequirement("Visualizations.Edit")));
     options.AddPolicy("Visualizations.Delete", policy => policy.Requirements.Add(new PermissionRequirement("Visualizations.Delete")));
 
+    // Módulo KPIs
+    options.AddPolicy("Kpis.View", policy => policy.Requirements.Add(new PermissionRequirement("Kpis.View")));
+    options.AddPolicy("Kpis.Create", policy => policy.Requirements.Add(new PermissionRequirement("Kpis.Create")));
+    options.AddPolicy("Kpis.Edit", policy => policy.Requirements.Add(new PermissionRequirement("Kpis.Edit")));
+    options.AddPolicy("Kpis.Delete", policy => policy.Requirements.Add(new PermissionRequirement("Kpis.Delete")));
+
     // Módulo Reports
     options.AddPolicy("Reports.View", policy => policy.Requirements.Add(new PermissionRequirement("Reports.View")));
     options.AddPolicy("Reports.Create", policy => policy.Requirements.Add(new PermissionRequirement("Reports.Create")));

--- a/OmniMonitor/Server/Services/VisualizacionService.cs
+++ b/OmniMonitor/Server/Services/VisualizacionService.cs
@@ -37,13 +37,13 @@ namespace OmniMonitor.Server.Services
         }
 
         /// <summary>
-        /// Crea una nueva visualizaci�n y asocia los datasets correspondientes.
+        /// Crea una nueva visualización y asocia los datasets correspondientes.
         /// </summary>
         public async Task<Visualizacion> CreateVisualizacionAsync(CreateVisualizacionRequest request)
         {
             if (string.IsNullOrEmpty(request.Username) || string.IsNullOrEmpty(request.Nombre))
             {
-                throw new ArgumentException("El nombre de usuario y el nombre de la visualizaci�n son obligatorios.");
+                throw new ArgumentException("El nombre de usuario y el nombre de la visualización son obligatorios.");
             }
 
             var nuevaVisualizacion = new Visualizacion
@@ -56,7 +56,7 @@ namespace OmniMonitor.Server.Services
                 Link = request.Link
             };
 
-            // A�adir los datasets asociados a la visualizaci�n
+            // Añadir los datasets asociados a la visualización
             if (request.Datasets != null && request.Datasets.Any())
             {
                 foreach (var datasetConfig in request.Datasets)
@@ -76,7 +76,7 @@ namespace OmniMonitor.Server.Services
         }
 
         /// <summary>
-        /// Obtiene todas las visualizaciones de un usuario espec�fico.
+        /// Obtiene todas las visualizaciones de un usuario específico.
         /// </summary>
         public async Task<List<Visualizacion>> GetAllVisualizacionesAsync(string username)
         {
@@ -119,7 +119,7 @@ namespace OmniMonitor.Server.Services
         }
 
         /// <summary>
-        /// Obtiene una visualizaci�n por su ID, incluyendo los datasets asociados.
+        /// Obtiene una visualización por su ID, incluyendo los datasets asociados.
         /// </summary>
         public async Task<Visualizacion?> GetVisualizacionByIdAsync(int idVisualizacion, string username)
         {


### PR DESCRIPTION
## Descripción

Agregué los permisos que faltaban en los endpoints nuevos: Dashboards.Edit para validate-cards, Dashboards.View para search, Visualizations.View en el paginado, Datasets.View en todos los listados UM y en DatasetFilterController.

Incorporé el módulo de permisos de KPIs, protegí cada acción del KPIController y ajusté los controladores de Sonda para que usen los permisos de Assets/Tasks/Events/Alerts/Zones/Sensors/Devices según corresponda.

## Ticket asociado

160
## Cómo probar

<!-- Instrucciones para testear el PR localmente -->

## Checklist

- [si ] Código compilado sin errores
- [ ] Tests locales ejecutados y aprobados
- [ si] Commit y branch nombrados con ticket correspondiente
- [ si] PR revisado y aprobado por los reviewers necesarios
