### PR TITLE
Feature: add live for im and em

### DIFF
--- a/OmniMonitor/Client/OmniMonitor.Client.csproj
+++ b/OmniMonitor/Client/OmniMonitor.Client.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -27,6 +27,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="9.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.8" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.8" />
     <PackageReference Include="MudBlazor" Version="8.11.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/OmniMonitor/Client/Pages/CreateDataset.razor
+++ b/OmniMonitor/Client/Pages/CreateDataset.razor
@@ -1758,7 +1758,6 @@
             var request = new CreateDatasetIMRequest
             {
                 Name = addName,
-                Username = username,
                 Description = addDesc,
                 IsDataset = "N", // Dataset no formal cuando se usa con filtros
                 ContentType = contentType,

--- a/OmniMonitor/Client/Pages/EditDashboard.razor
+++ b/OmniMonitor/Client/Pages/EditDashboard.razor
@@ -6,6 +6,7 @@
 @using Microsoft.AspNetCore.Components
 @using Microsoft.Extensions.Localization
 @using System.Text.Json;
+@using System.Threading.Tasks;
 @using Blazored.LocalStorage
 @inject HttpClient Http
 @inject IJSRuntime JS
@@ -16,6 +17,9 @@
 @inject IStringLocalizer<SharedResource> SharedLocalizer
 @inject ILocalStorageService LocalStorage
 @inject AuthenticationStateProvider AuthenticationStateProvider
+@inject OmniMonitor.Client.Services.SignalR.TelemetryHubClient TelemetryHubClient
+@inject OmniMonitor.Client.Services.SignalR.KpiHubClient KpiHubClient
+@implements IAsyncDisposable
 
 <PageTitle>Dashboards</PageTitle>
 
@@ -33,6 +37,10 @@
     </MudStack>
 
     <MudStack Row Spacing="2">
+        <MudStack Row AlignItems="AlignItems.Center" Class="mr-2">
+            <MudText Typo="Typo.body2" Class="mr-2">Live</MudText>
+            <MudSwitch T="bool" Value="@_liveOn" ValueChanged="OnLiveChanged" Color="MudBlazor.Color.Primary" Dense="true" />
+        </MudStack>
         <MudButton Variant="Variant.Outlined"
                    Color="MudBlazor.Color.Secondary"
                    StartIcon="@Icons.Material.Filled.Share"
@@ -55,13 +63,15 @@
     </MudText>
 </MudStack>
 
-<Dashboard CardsData=@(cardsData) 
-           dashboardId="@DashboardId" 
-           OnVisualizationCreated="HandleNewVisualization"
-           UsedVisualizations="@_visualizationsIDs"
-           UpdateCardSize="UpdateCardSize" 
-           RemoveCard="HandleDeleteVisualization">
-</Dashboard>
+<CascadingValue Value="@_liveOn">
+    <Dashboard CardsData=@(cardsData) 
+            dashboardId="@DashboardId" 
+            OnVisualizationCreated="HandleNewVisualization"
+            UsedVisualizations="@_visualizationsIDs"
+            UpdateCardSize="UpdateCardSize" 
+            RemoveCard="HandleDeleteVisualization">
+    </Dashboard>
+</CascadingValue>
 
 <style>
     @@media (max-width: 768px) {
@@ -91,7 +101,32 @@
 
     // ID, AnchoSm, AnchoMd, AnchoLg, Alto
     private List<(int Id, int CardType, int AnchoSm, int AnchoMd, int AnchoLg, int Alto)> cardsData = new List<(int, int, int, int, int, int)> { };
+    private bool _liveOn = false;
 
+    private void OnLiveChanged(bool v)
+    {
+        _liveOn = v;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var pair in _visualizationsIDs)
+        {
+            try
+            {
+                if (pair.Item2 == 2)
+                {
+                    await KpiHubClient.LeaveKpiAsync(pair.Item1);
+                }
+                else
+                {
+                    await TelemetryHubClient.LeaveVisualizationAsync(pair.Item1);
+                }
+            }
+            catch { }
+        }
+        try { await TelemetryHubClient.ShutdownIfIdleAsync(); } catch { }
+    }
 
     protected override async Task OnInitializedAsync()
     {

--- a/OmniMonitor/Client/Pages/EditDataset.razor
+++ b/OmniMonitor/Client/Pages/EditDataset.razor
@@ -2203,7 +2203,6 @@ else if (selectedTipo == "Insight Monitor")
             var request = new CreateDatasetIMRequest
             {
                 Name = addName,
-                Username = username,
                 Description = addDesc,
                 IsDataset = "N", // Dataset no formal cuando se usa con filtros
                 ContentType = contentType,

--- a/OmniMonitor/Client/Program.cs
+++ b/OmniMonitor/Client/Program.cs
@@ -51,6 +51,9 @@ builder.Services.AddScoped<VisualizationDraftService>();
 
 builder.Services.AddScoped<ShareLinkService>();
 
+builder.Services.AddScoped<OmniMonitor.Client.Services.SignalR.TelemetryHubClient>();
+builder.Services.AddScoped<OmniMonitor.Client.Services.SignalR.KpiHubClient>();
+
 builder.Services.AddLocalization(options => options.ResourcesPath = "Resources");
 
 // Configure JSON serialization options to handle enums as strings

--- a/OmniMonitor/Client/Services/SignalR/KpiHubClient.cs
+++ b/OmniMonitor/Client/Services/SignalR/KpiHubClient.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using Blazored.LocalStorage;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.SignalR.Client;
+using OmniMonitor.Shared.Dtos;
+
+namespace OmniMonitor.Client.Services.SignalR
+{
+    public class KpiHubClient : IAsyncDisposable
+    {
+        private readonly NavigationManager _nav;
+        private readonly ILocalStorageService _localStorage;
+        private HubConnection? _connection;
+        private readonly ConcurrentDictionary<int, byte> _joinedKpis = new();
+
+        public event Action<KpiResponse>? KpiUpdated;
+        public event Action<ConnectionState>? ConnectionStateChanged;
+
+        public KpiHubClient(NavigationManager nav, ILocalStorageService localStorage)
+        {
+            _nav = nav;
+            _localStorage = localStorage;
+        }
+
+        private async Task<HubConnection> EnsureConnectionAsync()
+        {
+            if (_connection is { State: HubConnectionState.Connected or HubConnectionState.Connecting or HubConnectionState.Reconnecting })
+            {
+                return _connection;
+            }
+
+            string baseUrl = _nav.BaseUri.TrimEnd('/');
+
+            _connection = new HubConnectionBuilder()
+                .WithUrl(baseUrl + "/hubs/kpi", options =>
+                {
+                    options.AccessTokenProvider = async () => await _localStorage.GetItemAsync<string>("authToken") ?? string.Empty;
+                })
+                .WithAutomaticReconnect()
+                .Build();
+
+            _connection.On<KpiResponse>("kpiUpdate", resp =>
+            {
+                KpiUpdated?.Invoke(resp);
+            });
+
+            _connection.Reconnecting += (ex) =>
+            {
+                ConnectionStateChanged?.Invoke(ConnectionState.Reconnecting);
+                return Task.CompletedTask;
+            };
+            _connection.Reconnected += async (id) =>
+            {
+                ConnectionStateChanged?.Invoke(ConnectionState.Connected);
+                // Rejoin KPIs after reconnect
+                try
+                {
+                    foreach (var kv in _joinedKpis.Keys)
+                    {
+                        try { await _connection.InvokeAsync("JoinKpi", kv); } catch { }
+                    }
+                }
+                catch { }
+            };
+            _connection.Closed += (ex) =>
+            {
+                ConnectionStateChanged?.Invoke(ConnectionState.Disconnected);
+                return Task.CompletedTask;
+            };
+
+            await _connection.StartAsync();
+            ConnectionStateChanged?.Invoke(ConnectionState.Connected);
+            return _connection;
+        }
+
+        public async Task JoinKpiAsync(int kpiId)
+        {
+            _joinedKpis.TryAdd(kpiId, 0);
+            var conn = await EnsureConnectionAsync();
+            await conn.InvokeAsync("JoinKpi", kpiId);
+        }
+
+        public async Task LeaveKpiAsync(int kpiId)
+        {
+            if (_connection is { State: HubConnectionState.Connected })
+            {
+                await _connection.InvokeAsync("LeaveKpi", kpiId);
+            }
+            _joinedKpis.TryRemove(kpiId, out _);
+            await ShutdownIfIdleAsync();
+        }
+
+        public async Task ShutdownIfIdleAsync()
+        {
+            if (_joinedKpis.IsEmpty && _connection is { } conn)
+            {
+                try { await conn.StopAsync(); } catch { }
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (_connection != null)
+            {
+                await _connection.DisposeAsync();
+                _connection = null;
+            }
+        }
+    }
+}

--- a/OmniMonitor/Client/Services/SignalR/TelemetryHubClient.cs
+++ b/OmniMonitor/Client/Services/SignalR/TelemetryHubClient.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using Blazored.LocalStorage;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.SignalR.Client;
+using System.Text.Json.Serialization;
+
+namespace OmniMonitor.Client.Services.SignalR
+{
+    public class TelemetryPointMessage
+    {
+        [JsonPropertyName("visualizationId")] public int VisualizationId { get; set; }
+        [JsonPropertyName("datasetId")] public int DatasetId { get; set; }
+        [JsonPropertyName("deviceId")] public int DeviceId { get; set; }
+        [JsonPropertyName("time")] public DateTime Time { get; set; }
+        [JsonPropertyName("value")] public double? Value { get; set; }
+        [JsonPropertyName("raw")] public string? Raw { get; set; }
+    }
+
+    public enum ConnectionState
+    {
+        Connected,
+        Reconnecting,
+        Disconnected
+    }
+
+    public class TelemetryHubClient : IAsyncDisposable
+    {
+        private readonly NavigationManager _nav;
+        private readonly ILocalStorageService _localStorage;
+        private HubConnection? _connection;
+        private readonly ConcurrentDictionary<int, byte> _joinedVisualizations = new();
+
+        public event Action<TelemetryPointMessage>? TelemetryReceived;
+        public event Action<ConnectionState>? ConnectionStateChanged;
+
+        public TelemetryHubClient(NavigationManager nav, ILocalStorageService localStorage)
+        {
+            _nav = nav;
+            _localStorage = localStorage;
+        }
+
+        private async Task<HubConnection> EnsureConnectionAsync()
+        {
+            if (_connection is { State: HubConnectionState.Connected or HubConnectionState.Connecting or HubConnectionState.Reconnecting })
+            {
+                return _connection;
+            }
+
+            string baseUrl = _nav.BaseUri.TrimEnd('/');
+
+            _connection = new HubConnectionBuilder()
+                .WithUrl(baseUrl + "/hubs/telemetry", options =>
+                {
+                    options.AccessTokenProvider = async () => await _localStorage.GetItemAsync<string>("authToken") ?? string.Empty;
+                })
+                .WithAutomaticReconnect()
+                .Build();
+
+            _connection.On<TelemetryPointMessage>("telemetryPoint", msg =>
+            {
+                TelemetryReceived?.Invoke(msg);
+            });
+
+            _connection.Reconnecting += (ex) =>
+            {
+                ConnectionStateChanged?.Invoke(ConnectionState.Reconnecting);
+                return Task.CompletedTask;
+            };
+            _connection.Reconnected += async (id) =>
+            {
+                ConnectionStateChanged?.Invoke(ConnectionState.Connected);
+                // Rejoin any visualizations we had joined before reconnect
+                try
+                {
+                    foreach (var kv in _joinedVisualizations.Keys)
+                    {
+                        try { await _connection.InvokeAsync("JoinVisualization", kv); } catch { }
+                    }
+                }
+                catch { }
+            };
+            _connection.Closed += (ex) =>
+            {
+                ConnectionStateChanged?.Invoke(ConnectionState.Disconnected);
+                return Task.CompletedTask;
+            };
+
+            await _connection.StartAsync();
+            ConnectionStateChanged?.Invoke(ConnectionState.Connected);
+            return _connection;
+        }
+
+        public async Task JoinVisualizationAsync(int visualizationId)
+        {
+            _joinedVisualizations.TryAdd(visualizationId, 0);
+            var conn = await EnsureConnectionAsync();
+            await conn.InvokeAsync("JoinVisualization", visualizationId);
+        }
+
+        public async Task LeaveVisualizationAsync(int visualizationId)
+        {
+            if (_connection is { State: HubConnectionState.Connected })
+            {
+                await _connection.InvokeAsync("LeaveVisualization", visualizationId);
+            }
+            _joinedVisualizations.TryRemove(visualizationId, out _);
+            await ShutdownIfIdleAsync();
+        }
+
+        public async Task ShutdownIfIdleAsync()
+        {
+            if (_joinedVisualizations.IsEmpty && _connection is { } conn)
+            {
+                try { await conn.StopAsync(); } catch { }
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (_connection != null)
+            {
+                await _connection.DisposeAsync();
+                _connection = null;
+            }
+        }
+    }
+}

--- a/OmniMonitor/Client/Shared/ChartViewer.razor
+++ b/OmniMonitor/Client/Shared/ChartViewer.razor
@@ -12,7 +12,8 @@
 @inject IStringLocalizer<ChartViewer> Localizer
 @inject ILocalStorageService LocalStorage
 @inject AuthenticationStateProvider AuthenticationStateProvider
-
+@inject OmniMonitor.Client.Services.SignalR.TelemetryHubClient TelemetryHubClient
+@implements IAsyncDisposable
 
 
 <MudItem Style="background-color: transparent; display:flex; flex-direction:column; height: 100%">
@@ -31,8 +32,14 @@
                     }
                 </CardHeaderAvatar>
                 <CardHeaderContent>
-                    @if (ShowTitle) {   
-                        <MudText Typo="Typo.h6" Style="color: var(--card-t+ext-primary)" >@_title</MudText>
+                    @if (ShowTitle) {
+                        <MudStack Row AlignItems="AlignItems.Center" Spacing="1">
+                            <MudText Typo="Typo.h6" Style="color: var(--card-t+ext-primary)">@_title</MudText>
+                            @if (LiveOn && Visualization != null && Visualization.LiveEnabled)
+                            {
+                                <MudIcon Icon="@Icons.Material.Filled.FiberManualRecord" Color="MudBlazor.Color.Error" Size="MudBlazor.Size.Small" />
+                            }
+                        </MudStack>
                     }
                 </CardHeaderContent>
 
@@ -48,6 +55,14 @@
                             </MudMenuItem>
                         </MudMenu>
                     }
+                    @if (_connState == OmniMonitor.Client.Services.SignalR.ConnectionState.Reconnecting)
+                    {
+                        <MudChip T="string" Color="MudBlazor.Color.Warning" Variant="Variant.Outlined" Size="MudBlazor.Size.Small">Reconnecting…</MudChip>
+                    }
+                    else if (_connState == OmniMonitor.Client.Services.SignalR.ConnectionState.Disconnected && _liveJoined)
+                    {
+                        <MudChip T="string" Color="MudBlazor.Color.Error" Variant="Variant.Outlined" Size="MudBlazor.Size.Small">Disconnected</MudChip>
+                    }
                 </CardHeaderActions>
                 
             </MudCardHeader>
@@ -57,14 +72,14 @@
                 @if(_dataRetrieved){
                     @if (_seriesData.Any())
                     {
-                        <ApexChart @key="_chartKey" TItem="ChartPoint" Height="270" Options="_chartOptions">
+                        <ApexChart @ref="_apexChart" @key="_chartKey" TItem="ChartPoint" Height="270" Options="_chartOptions">
                             @foreach (DatasetSeries serie in _seriesData)
                             {
                                 <ApexPointSeries TItem="ChartPoint"
                                                 Items="serie.Points"
                                                 Name="@serie.DatasetName"
                                                 SeriesType="@_seriesType"
-                                                XValue="@(p => p.X)"
+                                                XValue="@(p => p.T)"
                                                 YValue="@(p => (decimal)p.Y)"
                                                 Color="@serie.Color" />
                             }
@@ -111,6 +126,7 @@
 
     //Parametros
     [Parameter] public int VisualizationId { get; set; }
+    [Parameter] public bool LiveOn { get; set; }
 
     [Parameter] public Visualizacion? Visualization { get; set; }
 
@@ -144,6 +160,7 @@
 
     private System.String _title { get; set; } = string.Empty;
     private System.String _datasetNames { get; set; } = string.Empty;
+    private DateTime _lastUpdatedAt = default;
 
     // Chart Variables
     private SeriesType _seriesType = SeriesType.Line;
@@ -155,6 +172,7 @@
     {
         Xaxis = new XAxis
         {
+            Type = XAxisType.Datetime,
             TickAmount = 4,
             Labels = new XAxisLabels
             {
@@ -170,6 +188,196 @@
     protected override async Task OnInitializedAsync()
     {
         await DownloadVisualization();
+        await SetupLiveAsync();
+    }
+
+    private bool _liveJoined = false;
+    private OmniMonitor.Client.Services.SignalR.ConnectionState _connState = OmniMonitor.Client.Services.SignalR.ConnectionState.Connected;
+    private long _seq = 0;
+
+    private async Task SetupLiveAsync()
+    {
+        if (Visualization != null && Visualization.LiveEnabled && LiveOn)
+        {
+            TelemetryHubClient.ConnectionStateChanged += OnConnStateChanged;
+            TelemetryHubClient.TelemetryReceived += OnTelemetryPoint;
+            await TelemetryHubClient.JoinVisualizationAsync(VisualizationId);
+            _liveJoined = true;
+        }
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (Visualization == null)
+        {
+            return;
+        }
+        if (LiveOn && Visualization.LiveEnabled)
+        {
+            if (!_liveJoined)
+            {
+                try
+                {
+                    TelemetryHubClient.ConnectionStateChanged += OnConnStateChanged;
+                    TelemetryHubClient.TelemetryReceived += OnTelemetryPoint;
+                    await TelemetryHubClient.JoinVisualizationAsync(VisualizationId);
+                    _liveJoined = true;
+                }
+                catch { }
+            }
+        }
+        else
+        {
+            if (_liveJoined)
+            {
+                try { await TelemetryHubClient.LeaveVisualizationAsync(VisualizationId); } catch { }
+                TelemetryHubClient.TelemetryReceived -= OnTelemetryPoint;
+                TelemetryHubClient.ConnectionStateChanged -= OnConnStateChanged;
+                _liveJoined = false;
+            }
+        }
+    }
+
+    private void OnTelemetryPoint(OmniMonitor.Client.Services.SignalR.TelemetryPointMessage msg)
+    {
+        if (Visualization == null) return;
+        if (msg.VisualizationId != VisualizationId) return;
+
+        var gd = Visualization.GrupoDatasets.FirstOrDefault(g => g.DatasetId == msg.DatasetId);
+        if (gd == null) return;
+
+        decimal multiplier = 1;
+        string color = "#00FFE7";
+        try
+        {
+            using var doc = System.Text.Json.JsonDocument.Parse(gd.JsonDesign);
+            var root = doc.RootElement;
+            if (root.TryGetProperty("Multiplier", out var multProp) && multProp.ValueKind == System.Text.Json.JsonValueKind.Number)
+            {
+                multiplier = multProp.GetDecimal();
+            }
+            if (root.TryGetProperty("Color", out var colorProp) && colorProp.ValueKind == System.Text.Json.JsonValueKind.String)
+            {
+                color = colorProp.GetString() ?? color;
+            }
+        }
+        catch { }
+
+        decimal y = 0;
+        if (msg.Value.HasValue)
+        {
+            y = (decimal)msg.Value.Value;
+        }
+        else if (!string.IsNullOrWhiteSpace(msg.Raw))
+        {
+            if (!decimal.TryParse(msg.Raw, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out y))
+            {
+                if (string.Equals(msg.Raw, "True", StringComparison.OrdinalIgnoreCase)) y = 1;
+                else y = 0;
+            }
+        }
+        y *= multiplier;
+
+        string datasetName = gd.Dataset?.NameDataset ?? "Dataset";
+        string x = msg.Time.ToString("dd/MM/yyyy HH:mm:ss");
+
+        var serie = _seriesData.FirstOrDefault(s => s.DatasetName == datasetName);
+        if (serie == null)
+        {
+            serie = new DatasetSeries { DatasetName = datasetName, Color = color };
+            _seriesData.Add(serie);
+        }
+        // If an existing point for this second exists anywhere, update it instead of appending
+        int existingIdx = -1;
+        for (int i = serie.Points.Count - 1; i >= 0; i--)
+        {
+            if (serie.Points[i].X == x)
+            {
+                existingIdx = i;
+                break;
+            }
+        }
+
+        if (existingIdx >= 0)
+        {
+            var existing = serie.Points[existingIdx];
+            if (existing.Y == y)
+            {
+                return; // exact duplicate
+            }
+            serie.Points[existingIdx] = new ChartPoint { X = x, Y = y, Seq = ++_seq, T = msg.Time };
+        }
+        else
+        {
+            serie.Points.Add(new ChartPoint { X = x, Y = y, Seq = ++_seq, T = msg.Time });
+        }
+        SortSeriesByTime(serie);
+
+        TrimSeriesToWindow();
+
+        _lastUpdatedAt = DateTime.Now;
+
+        _seriesData = _seriesData
+            .Select(s => new DatasetSeries { DatasetName = s.DatasetName, Color = s.Color, Points = s.Points.ToList() })
+            .ToList();
+
+        _chartKey++;
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    private void OnConnStateChanged(OmniMonitor.Client.Services.SignalR.ConnectionState state)
+    {
+        _connState = state;
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    private void TrimSeriesToWindow()
+    {
+        try
+        {
+            if (Visualization == null) return;
+            TimeSpan span = Visualization.FechaHasta - Visualization.FechaDesde;
+            if (span.TotalSeconds <= 0) return;
+            DateTime thresholdLocal = DateTime.Now - span;
+            foreach (var s in _seriesData)
+            {
+                // Remove older points and cap length
+                s.Points.RemoveAll(p => p.T != default && p.T < thresholdLocal);
+                const int MaxPoints = 1500;
+                if (s.Points.Count > MaxPoints)
+                {
+                    int toRemove = s.Points.Count - MaxPoints;
+                    s.Points.RemoveRange(0, Math.Min(toRemove, s.Points.Count));
+                }
+            }
+        }
+        catch { }
+    }
+
+    private static void SortSeriesByTime(DatasetSeries serie)
+    {
+        try
+        {
+            serie.Points = serie.Points
+                .OrderBy(p => p.T != default ? p.T : DateTime.MinValue)
+                .ThenBy(p => p.Seq)
+                .ToList();
+        }
+        catch { }
+    }
+
+    private static bool TryParsePointTime(string x, out DateTime dt)
+    {
+        return DateTime.TryParseExact(x, "dd/MM/yyyy HH:mm:ss", System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.None, out dt)
+            || DateTime.TryParseExact(x, "dd/MM/yyyy HH:mm", System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.None, out dt);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        try { await TelemetryHubClient.LeaveVisualizationAsync(VisualizationId); } catch { }
+        TelemetryHubClient.TelemetryReceived -= OnTelemetryPoint;
+        TelemetryHubClient.ConnectionStateChanged -= OnConnStateChanged;
+        _liveJoined = false;
     }
 
     private async Task DownloadVisualization()
@@ -313,7 +521,7 @@
                                                             Timestamp = data.Time,
                                                             Value = numericValue * multiplier,
                                                             Color = color,
-                                                            DatasetName = dataset.Name,
+                                                            DatasetName = grupoDataset.Dataset.NameDataset,
                                                             SensorName = dataset.SensorName,
                                                             DeviceId = datasetDevice.Id_device
                                                         });
@@ -392,6 +600,7 @@
             }
             _retrievingData = false;
             _dataRetrieved = true;
+            _lastUpdatedAt = DateTime.Now;
             StateHasChanged();
         }
         catch (Exception ex)
@@ -435,9 +644,10 @@
                     ? colorProp.GetString() ?? "#00FFE7"
                     : "#00FFE7";
 
-                System.String? timestamp = root.TryGetProperty("Timestamp", out var tProp)
-                    ? tProp.GetDateTime().ToString("dd/MM/yyyy HH:mm")
-                    : null;
+                DateTime? tdt = root.TryGetProperty("Timestamp", out var tProp)
+                    ? tProp.GetDateTime()
+                    : (DateTime?)null;
+                System.String? timestamp = tdt.HasValue ? tdt.Value.ToString("dd/MM/yyyy HH:mm:ss") : null;
 
                 double value = 0;
                 if (root.TryGetProperty("Value", out var vProp))
@@ -456,8 +666,10 @@
 
                 grouped[datasetName].Points.Add(new ChartPoint
                 {
-                    X = timestamp ?? DateTime.Now.ToString("HH:mm"),
-                    Y = (decimal)value
+                    X = timestamp ?? DateTime.Now.ToString("HH:mm:ss"),
+                    Y = (decimal)value,
+                    Seq = ++_seq,
+                    T = (tdt ?? DateTime.Now)
                 });
             }
             catch (Exception ex)
@@ -539,6 +751,8 @@
     {
         public System.String X { get; set; } = string.Empty;
         public decimal Y { get; set; }
+        public System.DateTime T { get; set; }
+        public long Seq { get; set; }
     }
 
 }

--- a/OmniMonitor/Client/Shared/CreateKpiCard.razor
+++ b/OmniMonitor/Client/Shared/CreateKpiCard.razor
@@ -98,6 +98,12 @@
                               MaxLength="200"
                               Style="background: var(--card);" />
 
+                <!-- Live toggle -->
+                <MudStack Row AlignItems="AlignItems.Center">
+                    <MudText Typo="Typo.body2" Class="mr-2">@Localizer["Live"]</MudText>
+                    <MudSwitch T="bool" Value="@_liveEnabled" ValueChanged="OnLiveSwitchChanged" Color="MudBlazor.Color.Primary" Dense="true" Disabled="@(!_liveAllowedKpi)" />
+                </MudStack>
+
                 <!-- Module-specific UI -->
                 <!-- Si el módulo soporta métricas mostramos la select de métricas -->
                 @if (ModuleHasMetric)
@@ -324,6 +330,8 @@
     private bool _isTypeLocked = false;
     private bool _isFetchingAttributes = false;
     private bool _isFetchingAttributeValues = false;
+    private bool _liveEnabled = false;
+    private bool _liveAllowedKpi = false;
 
     private List<ColorRange> _colorRanges = new();
 
@@ -512,6 +520,8 @@
 
         // Si el módulo es AM/EM/UM asumimos dataset numérico (no hacemos la comprobación)
         var moduleCode = GetModuleCode(_selectedModuleName);
+        _liveAllowedKpi = !string.IsNullOrWhiteSpace(moduleCode) && (moduleCode.Equals("im", StringComparison.OrdinalIgnoreCase) || moduleCode.Equals("em", StringComparison.OrdinalIgnoreCase));
+        if (!_liveAllowedKpi) { _liveEnabled = false; }
         if (!string.IsNullOrWhiteSpace(moduleCode) &&
             (moduleCode.Equals("am", StringComparison.OrdinalIgnoreCase)
              || moduleCode.Equals("em", StringComparison.OrdinalIgnoreCase)
@@ -583,6 +593,7 @@
             "asset manager" => "am",
             "am" => "am",
             "event manager" => "em",
+            "event monitor" => "em",
             "em" => "em",
             "urban monitor" => "um",
             "um" => "um",
@@ -789,6 +800,12 @@
 
     private void Cancel() => _mudDialog.Cancel();
 
+    private void OnLiveSwitchChanged(bool value)
+    {
+        if (!_liveAllowedKpi) { return; }
+        _liveEnabled = value;
+    }
+
     // 4) IsFormValid actualizado: exigir metrica para esos modulos
     private bool IsFormValid
     {
@@ -917,7 +934,8 @@
             SourceModule = GetModuleCode(_selectedModuleName)?.ToUpperInvariant() ?? _selectedModuleName,
             // Non-IM fields
             Atributo = !string.IsNullOrWhiteSpace(_selectedAtributo) ? _selectedAtributo : null,
-            Type = _selectedType
+            Type = _selectedType,
+            LiveEnabled = _liveEnabled && _liveAllowedKpi
         };
 
         _isSubmitting = true;

--- a/OmniMonitor/Client/Shared/CreateVisualizationCard.razor
+++ b/OmniMonitor/Client/Shared/CreateVisualizationCard.razor
@@ -115,6 +115,11 @@
                       RequiredError="@Localizer["NameRequired"]"
                       Style="background: var(--card);" />
 
+        <MudStack Row AlignItems="AlignItems.Center" Class="mb-2">
+            <MudText Typo="Typo.body2" Class="mr-2">@Localizer["Live"]</MudText>
+            <MudSwitch T="bool" Value="@_liveEnabled" ValueChanged="OnLiveSwitchChanged" Color="MudBlazor.Color.Primary" Dense="true" Disabled="@(!_liveAllowedVis)" />
+        </MudStack>
+
         <MudText Typo="Typo.h6" Style="color: var(--text-primary);">@Localizer["ChartType"]</MudText>
         <MudSelect T="string"
                    @bind-Value="_selectedChartType"
@@ -185,6 +190,9 @@
     private TimeSpan? _endHour { get; set; }
     private string _visualizationName { get; set; } = string.Empty;
     private DashboardSummaryResponse _selectedDashboard { get; set; } = null;
+    private bool _liveEnabled = false;
+    private bool _liveAllowedVis = false;
+
     private List<DatasetSelection> _selectedDatasets = new List<DatasetSelection>();
     private Dictionary<string, List<string>> _entityAttributes = new Dictionary<string, List<string>>
     {
@@ -258,6 +266,7 @@
             Color = "rgb(0, 255, 231)"
         });
         Snackbar.Add(Localizer["DatasetAdded"], Severity.Info);
+        RecomputeLiveAllowed();
         StateHasChanged();
         return;
     }
@@ -362,7 +371,8 @@
                     })
                 }).ToList(),
                 FechaDesde = _beginDate.Value.Date + _beginHour.Value,
-                FechaHasta = _endDate.Value.Date + _endHour.Value
+                FechaHasta = _endDate.Value.Date + _endHour.Value,
+                LiveEnabled = _liveEnabled && _liveAllowedVis
             };
             try
             {
@@ -483,7 +493,28 @@
         if (found != null)
         {
             _selectedDatasets.Remove(found);
+            RecomputeLiveAllowed();
             StateHasChanged();
+        }
+    }
+
+    private void OnLiveSwitchChanged(bool value)
+    {
+        if (!_liveAllowedVis) { return; }
+        _liveEnabled = value;
+    }
+
+    private void RecomputeLiveAllowed()
+    {
+        _liveAllowedVis = _selectedDatasets.All(ds =>
+            !string.Equals(ds.Dataset.Module, "Asset Manager", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(ds.Dataset.Module, "Urban Monitor", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(ds.Dataset.Module, "AM", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(ds.Dataset.Module, "UM", StringComparison.OrdinalIgnoreCase)
+        );
+        if (!_liveAllowedVis)
+        {
+            _liveEnabled = false;
         }
     }
 

--- a/OmniMonitor/Client/Shared/DashboardCard.razor
+++ b/OmniMonitor/Client/Shared/DashboardCard.razor
@@ -66,7 +66,7 @@
         {
             
 
-            <ChartViewer @key="_chartViewerKey" ChartReloadKey="@_chartKey" VisualizationId="VisualizationId" />
+            <ChartViewer @key="_chartViewerKey" ChartReloadKey="@_chartKey" VisualizationId="VisualizationId" LiveOn="LiveOn" />
             
 
         } 
@@ -85,6 +85,7 @@
 @code{
     //Parametro para saber el Breakpoint actual
     [CascadingParameter] public Breakpoint CurrentBreakpoint { get; set; }
+    [CascadingParameter] public bool LiveOn { get; set; }
 
     //Parametros
     [Parameter] public int dashboardId { get; set; }

--- a/OmniMonitor/Client/Shared/EditKpiCard.razor
+++ b/OmniMonitor/Client/Shared/EditKpiCard.razor
@@ -3,6 +3,7 @@
 @using Blazored.LocalStorage
 @using Microsoft.Extensions.Localization
 @using Microsoft.AspNetCore.Components
+@using System.Net.Http.Json
 @using MudBlazor
 @using System.Net
 
@@ -45,6 +46,17 @@
                             DisableAlpha="true"
                             Style="width:220px;" />
 
+            <MudStack Row AlignItems="AlignItems.Center">
+                <MudText Typo="Typo.body2" Class="mr-2">@Localizer["Live"]</MudText>
+                @if (_liveAllowed)
+                {
+                    <MudSwitch T="bool" Value="@_liveEnabled" ValueChanged="OnLiveSwitchChanged" Color="MudBlazor.Color.Primary" Dense="true" />
+                }
+                else
+                {
+                    <MudSwitch T="bool" Value="@_liveEnabled" Color="MudBlazor.Color.Primary" Dense="true" Disabled="true" />
+                }
+            </MudStack>
 
 
         </MudStack>
@@ -73,6 +85,8 @@
     private string _initialColor = "#FFFFFF";
     private bool _isSubmitting = false;
     private string? _serverError;
+    private bool _liveEnabled = false;
+    private bool _liveAllowed = false;
 
 
 
@@ -115,6 +129,65 @@
         _initialName = _name;
         _initialDescription = _description;
         _initialColor = _actualColor;
+        _liveEnabled = ExistingKpi.LiveEnabled;
+        RecomputeLiveAllowed();
+
+        if (string.IsNullOrWhiteSpace(ExistingKpi.SourceModule))
+        {
+            try
+            {
+                var fresh = await Http.GetFromJsonAsync<KpiResponse>($"api/KPI/{ExistingKpi.Id}");
+                if (fresh != null)
+                {
+                    var code = GetModuleCode(fresh.SourceModule);
+                    _liveAllowed = (code == "im" || code == "em");
+                    _liveEnabled = _liveAllowed && fresh.LiveEnabled;
+                    ExistingKpi.SourceModule = fresh.SourceModule;
+                    ExistingKpi.LiveEnabled = fresh.LiveEnabled;
+                    RecomputeLiveAllowed();
+                }
+            }
+            catch { }
+        }
+    }
+
+    protected override void OnParametersSet()
+    {
+        // Ensure gating reflects the latest parameter values (like EditVisualization does after loading currVisualization)
+        _liveEnabled = ExistingKpi.LiveEnabled;
+        RecomputeLiveAllowed();
+    }
+
+    
+
+    private string? GetModuleCode(string? moduleLong)
+    {
+        if (string.IsNullOrWhiteSpace(moduleLong)) return null;
+        var s = moduleLong.Trim().ToLowerInvariant();
+        // substring-based classification
+        if (s.Contains("insight")) return "im";
+        if (s.Contains("event")) return "em";
+        if (s.Contains("asset")) return "am";
+        if (s.Contains("urban")) return "um";
+        // exact fallbacks
+        return s switch
+        {
+            "am" => "am",
+            "em" => "em",
+            "um" => "um",
+            "im" => "im",
+            _ => s
+        };
+    }
+
+    private void RecomputeLiveAllowed()
+    {
+        var code = GetModuleCode(ExistingKpi.SourceModule);
+        _liveAllowed = (code == "im" || code == "em");
+        if (!_liveAllowed)
+        {
+            _liveEnabled = false;
+        }
     }
 
     private bool HasChanges =>
@@ -123,6 +196,12 @@
         !string.Equals(_actualColor, _initialColor, StringComparison.Ordinal);
 
     private bool IsFormValid => !string.IsNullOrWhiteSpace(_name) && HasChanges;
+
+    private void OnLiveSwitchChanged(bool value)
+    {
+        if (!_liveAllowed) { return; }
+        _liveEnabled = value;
+    }
 
     private async Task Submit()
     {
@@ -138,7 +217,8 @@
         {
             Name = _name.Trim(),
             Description = _description?.Trim(),
-            DefaultColor = _actualColor
+            DefaultColor = _actualColor,
+            LiveEnabled = _liveEnabled && _liveAllowed
         };
 
         try

--- a/OmniMonitor/Client/Shared/EditVisualizationDialog.razor
+++ b/OmniMonitor/Client/Shared/EditVisualizationDialog.razor
@@ -114,6 +114,11 @@
                       RequiredError="@Localizer["NameRequired"]"
                       Style="background: var(--card);" />
 
+        <MudStack Row AlignItems="AlignItems.Center" Class="mb-2">
+            <MudText Typo="Typo.body2" Class="mr-2">@Localizer["Live"]</MudText>
+            <MudSwitch T="bool" Value="@_liveEnabled" ValueChanged="OnLiveSwitchChanged" Color="MudBlazor.Color.Primary" Dense="true" Disabled="@(!_liveAllowedVis)" />
+        </MudStack>
+
         <MudText Typo="Typo.h6" Style="color: var(--text-primary);">@Localizer["ChartType"]</MudText>
         <MudSelect T="string"
                    @bind-Value="_selectedChartType"
@@ -193,6 +198,8 @@
     private TimeSpan? _endHour { get; set; }
     private string _visualizationName { get; set; } = string.Empty;
     private DashboardSummaryResponse _selectedDashboard { get; set; } = null;
+    private bool _liveEnabled = false;
+    private bool _liveAllowedVis = false;
     private List<DatasetSelection> _selectedDatasets = new List<DatasetSelection>();
     private Dictionary<System.String, List<System.String>> _entityAttributes = new Dictionary<System.String, List<System.String>>
     {
@@ -347,6 +354,7 @@
             Color = "rgb(0, 255, 231)"
         });
         Snackbar.Add(Localizer["DatasetAdded"], Severity.Info);
+        RecomputeLiveAllowed();
         StateHasChanged();
         return;
     }
@@ -435,7 +443,8 @@
                     })
                 }).ToList(),
                 FechaDesde = _beginDate.Value.Date + _beginHour.Value,
-                FechaHasta = _endDate.Value.Date + _endHour.Value
+                FechaHasta = _endDate.Value.Date + _endHour.Value,
+                LiveEnabled = _liveEnabled && _liveAllowedVis
             };
 
             try
@@ -524,9 +533,28 @@
 
     private void Cancel() => _mudDialog.Cancel();
 
+    
+
     private void RemoveDataset(DatasetSelection item)
     {
         _selectedDatasets.Remove(item);
+        RecomputeLiveAllowed();
+    }
+    
+    private void OnLiveSwitchChanged(bool value)
+    {
+        if (!_liveAllowedVis) { return; }
+        _liveEnabled = value;
+    }
+    
+    public class DatasetSelection
+    {
+        public DatasetDtoGenerico Dataset { get; set; } = new();
+        public System.String DisplayName { get; set; } = System.String.Empty;
+        public System.String Entity { get; set; } = System.String.Empty;
+        public System.String EntityAttribute { get; set; } = System.String.Empty;
+        public decimal Multiplier { get; set; }
+        public string Color { get; set; } = "rgb(0, 255, 231)";
     }
 
     private async Task<string> GetEntityFromDatasetAsync(System.Int32 datasetId, System.String module)
@@ -598,6 +626,20 @@
         {
             Snackbar.Add($"Error: {ex.Message}", Severity.Error);
             return string.Empty;
+        }
+    }
+
+    private void RecomputeLiveAllowed()
+    {
+        _liveAllowedVis = _selectedDatasets.All(ds =>
+            !string.Equals(ds.Dataset.Module, "Asset Manager", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(ds.Dataset.Module, "Urban Monitor", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(ds.Dataset.Module, "AM", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(ds.Dataset.Module, "UM", StringComparison.OrdinalIgnoreCase)
+        );
+        if (!_liveAllowedVis)
+        {
+            _liveEnabled = false;
         }
     }
 

--- a/OmniMonitor/Client/Shared/KpiViewer.razor
+++ b/OmniMonitor/Client/Shared/KpiViewer.razor
@@ -5,27 +5,47 @@
 @inject HttpClient Http
 @inject ILocalStorageService LocalStorage
 @inject IStringLocalizer<VisualizationCard> Localizer
+@inject OmniMonitor.Client.Services.SignalR.KpiHubClient KpiHubClient
+@implements IAsyncDisposable
 
 <MudPaper Class="pa-4 kpi-card" Style="@CardStyle">
     <MudCard Elevation="0"
              Style="background-color: transparent; display:flex; flex-direction:column; height:100%;">
         <MudCardContent Style="flex:1; display:flex; flex-direction:column;">
 
+            @if (_connState == OmniMonitor.Client.Services.SignalR.ConnectionState.Reconnecting)
+            {
+                <div style="align-self:flex-end; margin-bottom:4px;">
+                    <MudChip T="string" Color="MudBlazor.Color.Warning" Variant="Variant.Outlined" Size="MudBlazor.Size.Small">Reconnectingâ€¦</MudChip>
+                </div>
+            }
+            else if (_connState == OmniMonitor.Client.Services.SignalR.ConnectionState.Disconnected && _liveJoined)
+            {
+                <div style="align-self:flex-end; margin-bottom:4px;">
+                    <MudChip T="string" Color="MudBlazor.Color.Error" Variant="Variant.Outlined" Size="MudBlazor.Size.Small">Disconnected</MudChip>
+                </div>
+            }
+
             <!-- Name -->
             <MudTooltip Text="@Kpi.Name">
-                <MudText Class="mb-4"
-                         Typo="Typo.h6"
-                         Style="color: var(--card-text-primary);
-                                font-weight:600;
-                                white-space: nowrap;
-                                overflow: hidden;
-                                text-overflow: ellipsis;">
-                    @Kpi.Name
-                </MudText>
+                <MudStack Row AlignItems="AlignItems.Center" Spacing="1" Class="mb-4">
+                    <MudText Typo="Typo.h6"
+                             Style="color: var(--card-text-primary);
+                                    font-weight:600;
+                                    white-space: nowrap;
+                                    overflow: hidden;
+                                    text-overflow: ellipsis;">
+                        @Kpi.Name
+                    </MudText>
+                    @if (LiveOn && (Kpi?.LiveEnabled ?? false))
+                    {
+                        <MudIcon Icon="@Icons.Material.Filled.FiberManualRecord" Color="MudBlazor.Color.Error" Size="MudBlazor.Size.Small" />
+                    }
+                </MudStack>
             </MudTooltip>
 
             <!-- Value -->
-            @if (string.IsNullOrEmpty(Kpi.Value?.ToString()) || Kpi.Value?.ToString() == "—")
+            @if (string.IsNullOrEmpty(Kpi.Value?.ToString()) || Kpi.Value?.ToString() == "ï¿½")
             {
                 <MudText Typo="Typo.body2"
                          Style="color: var(--card-text-secondary); font-weight: bold;">
@@ -63,6 +83,8 @@
     public int KpiId { get; set; } = 0;
     [Parameter]
     public KpiResponse Kpi { get; set; } = new();
+    [CascadingParameter] public bool LiveOn { get; set; }
+    private DateTime _lastUpdatedAt = default;
 
     protected override async Task OnInitializedAsync()
     {
@@ -80,6 +102,7 @@
                     if (kpiData != null)
                     {
                         Kpi = kpiData;
+                        _lastUpdatedAt = DateTime.Now;
                     }
                 }
                 else
@@ -91,9 +114,68 @@
             }
             catch (Exception ex)
             {
-                // Snackbar.Add("Error de conexión al obtener KPI.", Severity.Error);
+                // Snackbar.Add("Error de conexiï¿½n al obtener KPI.", Severity.Error);
+            }
+
+            await SetupLiveAsync();
+        }
+    }
+
+    private bool _liveJoined = false;
+    private OmniMonitor.Client.Services.SignalR.ConnectionState _connState = OmniMonitor.Client.Services.SignalR.ConnectionState.Connected;
+
+    private async Task SetupLiveAsync()
+    {
+        if (LiveOn && KpiId != 0 && (Kpi?.LiveEnabled ?? false))
+        {
+            try
+            {
+                KpiHubClient.ConnectionStateChanged += OnConnStateChanged;
+                KpiHubClient.KpiUpdated += OnKpiUpdated;
+                await KpiHubClient.JoinKpiAsync(KpiId);
+                _liveJoined = true;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Live join failed for KPI {KpiId}: {ex.Message}");
             }
         }
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (KpiId == 0) return;
+        if (LiveOn && (Kpi?.LiveEnabled ?? false))
+        {
+            if (!_liveJoined)
+            {
+                await SetupLiveAsync();
+            }
+        }
+        else
+        {
+            if (_liveJoined)
+            {
+                try { await KpiHubClient.LeaveKpiAsync(KpiId); } catch { }
+                KpiHubClient.KpiUpdated -= OnKpiUpdated;
+                KpiHubClient.ConnectionStateChanged -= OnConnStateChanged;
+                _liveJoined = false;
+            }
+        }
+    }
+
+    private void OnKpiUpdated(KpiResponse resp)
+    {
+        if (resp == null || resp.Id != KpiId) return;
+        Kpi = resp;
+        _lastUpdatedAt = DateTime.Now;
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    private void OnConnStateChanged(OmniMonitor.Client.Services.SignalR.ConnectionState state)
+    {
+        _connState = state;
+        _ = InvokeAsync(StateHasChanged);
     }
 
     private string CardStyle =>
@@ -127,5 +209,13 @@
         }
 
         return colorInput;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        try { await KpiHubClient.LeaveKpiAsync(KpiId); } catch { }
+        KpiHubClient.KpiUpdated -= OnKpiUpdated;
+        KpiHubClient.ConnectionStateChanged -= OnConnStateChanged;
+        _liveJoined = false;
     }
 }

--- a/OmniMonitor/Server/Configuration/LiveOptions.cs
+++ b/OmniMonitor/Server/Configuration/LiveOptions.cs
@@ -1,0 +1,18 @@
+namespace OmniMonitor.Server.Configuration
+{
+    public class LiveOptions
+    {
+        public int ImChartIntervalSeconds { get; set; } = 3;
+        public int ImKpiIntervalSeconds { get; set; } = 5;
+        public int EmKpiIntervalSeconds { get; set; } = 15;
+        public BackoffOptions Backoff { get; set; } = new BackoffOptions();
+    }
+
+    public class BackoffOptions
+    {
+        public int BaseSeconds { get; set; } = 5;
+        public int MaxSeconds { get; set; } = 60;
+        public double Multiplier { get; set; } = 2.0;
+        public double JitterRatio { get; set; } = 0.2;
+    }
+}

--- a/OmniMonitor/Server/Controllers/DatasetController.cs
+++ b/OmniMonitor/Server/Controllers/DatasetController.cs
@@ -381,7 +381,6 @@ namespace OmniMonitor.Server.Controllers
                 if (request.IsDataset == "N" && request.Filters != null && request.Filters.Any())
                 {
                     // Validar filtros ANTES de actualizar
-                    var username = User.Identity?.Name;
                     if (string.IsNullOrWhiteSpace(username))
                         return BadRequest("Usuario no encontrado.");
 

--- a/OmniMonitor/Server/Controllers/VisualizacionController.cs
+++ b/OmniMonitor/Server/Controllers/VisualizacionController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using System.Text.Json;
 
 using OmniMonitor.Server.Attributes;
 using OmniMonitor.Server.Services;
@@ -284,6 +285,42 @@ namespace OmniMonitor.Server.Controllers
                 visualizacion.FechaHasta = request.FechaHasta;
                 visualizacion.JsonDesign = request.JsonDiseñoGeneral;
                 visualizacion.Link = request.Link;
+                bool requestedLive = request.LiveEnabled ?? visualizacion.LiveEnabled;
+                bool allowLive = requestedLive;
+                if (requestedLive && request.Datasets != null && request.Datasets.Any())
+                {
+                    foreach (var ds in request.Datasets)
+                    {
+                        try
+                        {
+                            using JsonDocument doc = JsonDocument.Parse(ds.JsonDiseño);
+                            if (doc.RootElement.TryGetProperty("Module", out JsonElement modEl))
+                            {
+                                string? module = modEl.GetString()?.Trim();
+                                if (string.IsNullOrWhiteSpace(module)
+                                    || string.Equals(module, "Asset Manager", StringComparison.OrdinalIgnoreCase)
+                                    || string.Equals(module, "Urban Monitor", StringComparison.OrdinalIgnoreCase)
+                                    || string.Equals(module, "AM", StringComparison.OrdinalIgnoreCase)
+                                    || string.Equals(module, "UM", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    allowLive = false;
+                                    break;
+                                }
+                            }
+                            else
+                            {
+                                allowLive = false;
+                                break;
+                            }
+                        }
+                        catch
+                        {
+                            allowLive = false;
+                            break;
+                        }
+                    }
+                }
+                visualizacion.LiveEnabled = allowLive;
 
                 // --- Sincronizar GrupoDatasets ---
                 var requestDatasetIds = request.Datasets.Select(ds => ds.DatasetId).ToHashSet();

--- a/OmniMonitor/Server/Hubs/KpiHub.cs
+++ b/OmniMonitor/Server/Hubs/KpiHub.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using OmniMonitor.Server.Context;
+using OmniMonitor.Server.Live;
+
+namespace OmniMonitor.Server.Hubs
+{
+    [Authorize]
+    public class KpiHub : Hub
+    {
+        private readonly ApplicationDbContext _db;
+        private readonly ILogger<KpiHub> _logger;
+        private readonly ILiveSubscriptionRegistry _registry;
+        private static readonly ConcurrentDictionary<string, ConcurrentDictionary<int, byte>> _connKpis = new();
+
+        public KpiHub(ApplicationDbContext db, ILogger<KpiHub> logger, ILiveSubscriptionRegistry registry)
+        {
+            _db = db;
+            _logger = logger;
+            _registry = registry;
+        }
+
+        private static string KpiGroupName(int kpiId) => $"kpi:{kpiId}";
+
+        private string GetUsernameOrThrow()
+        {
+            string? name = Context?.User?.Identity?.Name;
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new HubException("Unauthorized: missing identity");
+            }
+            return name;
+        }
+
+        public override Task OnConnectedAsync()
+        {
+            _logger.LogInformation("KpiHub connected: {ConnectionId}", Context.ConnectionId);
+            return base.OnConnectedAsync();
+        }
+
+        public override Task OnDisconnectedAsync(Exception? exception)
+        {
+            _logger.LogInformation("KpiHub disconnected: {ConnectionId}. Error: {Error}", Context.ConnectionId, exception?.Message);
+            if (_connKpis.TryRemove(Context.ConnectionId, out var set))
+            {
+                foreach (var kv in set)
+                {
+                    _ = _registry.UnregisterKpiAsync(kv.Key);
+                }
+            }
+            return base.OnDisconnectedAsync(exception);
+        }
+
+        public async Task JoinKpi(int kpiId)
+        {
+            if (kpiId <= 0)
+            {
+                throw new HubException("Invalid kpi id");
+            }
+
+            string username = GetUsernameOrThrow();
+            var kpi = await _db.Kpi.FirstOrDefaultAsync(k => k.Id == kpiId);
+            if (kpi == null)
+            {
+                throw new HubException("NotFound: KPI does not exist");
+            }
+
+            if (!string.Equals(kpi.Username, username, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new HubException("Forbidden: you do not have access to this KPI");
+            }
+
+            if (!kpi.LiveEnabled)
+            {
+                throw new HubException("Live is disabled for this KPI");
+            }
+
+            string group = KpiGroupName(kpiId);
+            await Groups.AddToGroupAsync(Context.ConnectionId, group);
+            var set = _connKpis.GetOrAdd(Context.ConnectionId, _ => new ConcurrentDictionary<int, byte>());
+            if (set.TryAdd(kpiId, 0))
+            {
+                await _registry.RegisterKpiAsync(kpiId);
+            }
+            _logger.LogInformation("User {User} joined group {Group}", username, group);
+        }
+
+        public async Task LeaveKpi(int kpiId)
+        {
+            if (kpiId <= 0)
+            {
+                return;
+            }
+
+            string group = KpiGroupName(kpiId);
+            await Groups.RemoveFromGroupAsync(Context.ConnectionId, group);
+            if (_connKpis.TryGetValue(Context.ConnectionId, out var set) && set.TryRemove(kpiId, out _))
+            {
+                await _registry.UnregisterKpiAsync(kpiId);
+            }
+            _logger.LogInformation("Connection {Conn} left group {Group}", Context.ConnectionId, group);
+        }
+    }
+}

--- a/OmniMonitor/Server/Hubs/TelemetryHub.cs
+++ b/OmniMonitor/Server/Hubs/TelemetryHub.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Concurrent;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using OmniMonitor.Server.Context;
+using OmniMonitor.Server.Live;
+
+namespace OmniMonitor.Server.Hubs
+{
+    [Authorize]
+    public class TelemetryHub : Hub
+    {
+        private readonly ApplicationDbContext _db;
+        private readonly ILogger<TelemetryHub> _logger;
+        private readonly ILiveSubscriptionRegistry _registry;
+        private static readonly ConcurrentDictionary<string, ConcurrentDictionary<int, byte>> _connVisualizations = new();
+
+        public TelemetryHub(ApplicationDbContext db, ILogger<TelemetryHub> logger, ILiveSubscriptionRegistry registry)
+        {
+            _db = db;
+            _logger = logger;
+            _registry = registry;
+        }
+
+        private static string VisualizationGroupName(int visualizationId) => $"visualization:{visualizationId}";
+
+        private string GetUsernameOrThrow()
+        {
+            string? name = Context?.User?.Identity?.Name;
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new HubException("Unauthorized: missing identity");
+            }
+            return name;
+        }
+
+        public override Task OnConnectedAsync()
+        {
+            _logger.LogInformation("TelemetryHub connected: {ConnectionId}", Context.ConnectionId);
+            return base.OnConnectedAsync();
+        }
+
+        public override Task OnDisconnectedAsync(Exception? exception)
+        {
+            _logger.LogInformation("TelemetryHub disconnected: {ConnectionId}. Error: {Error}", Context.ConnectionId, exception?.Message);
+            if (_connVisualizations.TryRemove(Context.ConnectionId, out var set))
+            {
+                foreach (var kv in set)
+                {
+                    _ = _registry.UnregisterVisualizationAsync(kv.Key);
+                }
+            }
+            return base.OnDisconnectedAsync(exception);
+        }
+
+        public async Task JoinVisualization(int visualizationId)
+        {
+            if (visualizationId <= 0)
+            {
+                throw new HubException("Invalid visualization id");
+            }
+
+            string username = GetUsernameOrThrow();
+            var vis = await _db.Visualizaciones.FirstOrDefaultAsync(v => v.IdVisualizacion == visualizationId);
+            if (vis == null)
+            {
+                throw new HubException("NotFound: visualization does not exist");
+            }
+
+            if (!string.Equals(vis.Username, username, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new HubException("Forbidden: you do not have access to this visualization");
+            }
+
+            if (!vis.LiveEnabled)
+            {
+                throw new HubException("Live is disabled for this visualization");
+            }
+
+            string group = VisualizationGroupName(visualizationId);
+            await Groups.AddToGroupAsync(Context.ConnectionId, group);
+            var set = _connVisualizations.GetOrAdd(Context.ConnectionId, _ => new ConcurrentDictionary<int, byte>());
+            if (set.TryAdd(visualizationId, 0))
+            {
+                await _registry.RegisterVisualizationAsync(visualizationId);
+            }
+            _logger.LogInformation("User {User} joined group {Group}", username, group);
+        }
+
+        public async Task LeaveVisualization(int visualizationId)
+        {
+            if (visualizationId <= 0)
+            {
+                return;
+            }
+
+            string group = VisualizationGroupName(visualizationId);
+            await Groups.RemoveFromGroupAsync(Context.ConnectionId, group);
+            if (_connVisualizations.TryGetValue(Context.ConnectionId, out var set) && set.TryRemove(visualizationId, out _))
+            {
+                await _registry.UnregisterVisualizationAsync(visualizationId);
+            }
+            _logger.LogInformation("Connection {Conn} left group {Group}", Context.ConnectionId, group);
+        }
+    }
+}

--- a/OmniMonitor/Server/Live/LivePollingHostedService.cs
+++ b/OmniMonitor/Server/Live/LivePollingHostedService.cs
@@ -1,0 +1,329 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using OmniMonitor.Server.Context;
+using OmniMonitor.Server.Configuration;
+using OmniMonitor.Server.Hubs;
+using OmniMonitor.Server.Services;
+using OmniMonitor.Shared.Dtos;
+
+namespace OmniMonitor.Server.Live
+{
+    public class LivePollingHostedService : BackgroundService
+    {
+        private readonly ILogger<LivePollingHostedService> _logger;
+        private readonly ILiveSubscriptionRegistry _registry;
+        private readonly LiveOptions _options;
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly IHubContext<TelemetryHub> _telemetryHub;
+        private readonly IHubContext<KpiHub> _kpiHub;
+
+        private readonly ConcurrentDictionary<int, CancellationTokenSource> _vizLoops = new();
+        private readonly ConcurrentDictionary<int, CancellationTokenSource> _kpiLoops = new();
+
+        public LivePollingHostedService(
+            ILogger<LivePollingHostedService> logger,
+            ILiveSubscriptionRegistry registry,
+            IServiceScopeFactory scopeFactory,
+            IHubContext<TelemetryHub> telemetryHub,
+            IHubContext<KpiHub> kpiHub,
+            IOptions<LiveOptions> options)
+        {
+            _logger = logger;
+            _registry = registry;
+            _scopeFactory = scopeFactory;
+            _telemetryHub = telemetryHub;
+            _kpiHub = kpiHub;
+            _options = options.Value;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            _logger.LogInformation("LivePollingHostedService started");
+            var reader = _registry.Changes;
+            await foreach (var change in reader.ReadAllAsync(stoppingToken))
+            {
+                try
+                {
+                    switch (change.Kind)
+                    {
+                        case SubscriptionKind.Visualization:
+                            if (change.Start)
+                            {
+                                StartVisualizationLoop(change.Id);
+                            }
+                            else
+                            {
+                                StopVisualizationLoop(change.Id);
+                            }
+                            break;
+                        case SubscriptionKind.Kpi:
+                            if (change.Start)
+                            {
+                                StartKpiLoop(change.Id);
+                            }
+                            else
+                            {
+                                StopKpiLoop(change.Id);
+                            }
+                            break;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error handling subscription change {Kind} {Id} {Start}", change.Kind, change.Id, change.Start);
+                }
+            }
+        }
+
+        private void StartVisualizationLoop(int visualizationId)
+        {
+            if (_vizLoops.ContainsKey(visualizationId)) return;
+
+            var cts = new CancellationTokenSource();
+            if (_vizLoops.TryAdd(visualizationId, cts))
+            {
+                _ = Task.Run(() => VisualizationLoopAsync(visualizationId, cts.Token));
+                _logger.LogInformation("Started visualization loop for {Id}", visualizationId);
+            }
+        }
+
+        private void StopVisualizationLoop(int visualizationId)
+        {
+            if (_vizLoops.TryRemove(visualizationId, out var cts))
+            {
+                cts.Cancel();
+                _logger.LogInformation("Stopped visualization loop for {Id}", visualizationId);
+            }
+        }
+
+        private void StartKpiLoop(int kpiId)
+        {
+            if (_kpiLoops.ContainsKey(kpiId)) return;
+            var cts = new CancellationTokenSource();
+            if (_kpiLoops.TryAdd(kpiId, cts))
+            {
+                _ = Task.Run(() => KpiLoopAsync(kpiId, cts.Token));
+                _logger.LogInformation("Started KPI loop for {Id}", kpiId);
+            }
+        }
+
+        private void StopKpiLoop(int kpiId)
+        {
+            if (_kpiLoops.TryRemove(kpiId, out var cts))
+            {
+                cts.Cancel();
+                _logger.LogInformation("Stopped KPI loop for {Id}", kpiId);
+            }
+        }
+
+        // IM visualization delta poller
+        private async Task VisualizationLoopAsync(int visualizationId, CancellationToken ct)
+        {
+            // Per-dataset last timestamp map
+            var lastTimestamps = new Dictionary<int, DateTime>(); // key: DatasetIM.Id
+            // Per (datasetId, deviceId) last broadcasted sample to suppress duplicates
+            var lastBroadcast = new Dictionary<(int DatasetId, int DeviceId), (DateTime Time, double? Value, string? Raw)>();
+
+            int backoff = _options.Backoff.BaseSeconds;
+            while (!ct.IsCancellationRequested)
+            {
+                try
+                {
+                    using var scope = _scopeFactory.CreateScope();
+                    var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                    var imService = scope.ServiceProvider.GetRequiredService<ISondaIMService>();
+
+                    var vis = await db.Visualizaciones
+                        .Include(v => v.GrupoDatasets)
+                        .FirstOrDefaultAsync(v => v.IdVisualizacion == visualizationId, ct);
+                    if (vis == null || !vis.LiveEnabled)
+                    {
+                        await Task.Delay(TimeSpan.FromSeconds(5), ct); // idle if missing/disabled
+                        continue;
+                    }
+
+                    string owner = vis.Username;
+                    var datasetIds = vis.GrupoDatasets.Select(g => g.DatasetId).ToList();
+                    if (datasetIds.Count == 0)
+                    {
+                        await Task.Delay(TimeSpan.FromSeconds(5), ct);
+                        continue;
+                    }
+
+                    // Map general dataset ids to IM datasets
+                    var imDatasets = await db.DatasetsIM
+                        .Include(d => d.DatasetDevices)
+                        .Where(d => d.Username == owner && datasetIds.Contains(d.DatasetId))
+                        .ToListAsync(ct);
+
+                    var now = DateTime.UtcNow;
+
+                    foreach (var dsim in imDatasets)
+                    {
+                        if (string.IsNullOrWhiteSpace(dsim.SensorName))
+                            continue;
+                        if (dsim.DatasetDevices == null || dsim.DatasetDevices.Count == 0)
+                            continue;
+
+                        // determine window
+                        if (!lastTimestamps.TryGetValue(dsim.Id, out var lastTs))
+                        {
+                            lastTs = now.AddSeconds(-_options.ImChartIntervalSeconds);
+                        }
+                        var from = lastTs.AddTicks(1);
+                        var to = now;
+                        if (from >= to) continue;
+
+                        foreach (var dev in dsim.DatasetDevices)
+                        {
+                            var points = await imService.GetSensorDataByDate(dev.Id_device, dsim.SensorName, from, to, owner);
+                            if (points == null || points.Count == 0) continue;
+
+                            // Broadcast only new points
+                            foreach (var p in points.OrderBy(x => x.Time))
+                            {
+                                // Try parse numeric value
+                                double? value = null;
+                                if (double.TryParse(p.Data, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var num))
+                                {
+                                    value = num;
+                                }
+
+                                // Server-side de-duplication: skip if same time/value already sent for this dataset/device
+                                var key = (dsim.DatasetId, dev.Id_device);
+                                if (lastBroadcast.TryGetValue(key, out var last))
+                                {
+                                    bool sameOrOlderTime = p.Time <= last.Time;
+                                    bool sameValue = value.HasValue ? (last.Value.HasValue && Math.Abs(last.Value.Value - value.Value) < 1e-12)
+                                                                     : string.Equals(p.Data, last.Raw, StringComparison.Ordinal);
+                                    if (sameOrOlderTime && sameValue)
+                                    {
+                                        continue;
+                                    }
+                                }
+
+                                var payload = new
+                                {
+                                    visualizationId,
+                                    datasetId = dsim.DatasetId,
+                                    deviceId = dev.Id_device,
+                                    time = p.Time,
+                                    value,
+                                    raw = p.Data
+                                };
+
+                                await _telemetryHub.Clients.Group($"visualization:{visualizationId}")
+                                    .SendAsync("telemetryPoint", payload, ct);
+
+                                if (p.Time > lastTs)
+                                {
+                                    lastTs = p.Time;
+                                }
+
+                                // Update last broadcasted sample
+                                lastBroadcast[key] = (p.Time, value, p.Data);
+                            }
+                        }
+
+                        lastTimestamps[dsim.Id] = lastTs;
+                    }
+
+                    backoff = _options.Backoff.BaseSeconds; // reset on success
+                    await Task.Delay(TimeSpan.FromSeconds(_options.ImChartIntervalSeconds), ct);
+                }
+                catch (OperationCanceledException)
+                {
+                    // normal on stop
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Visualization loop error for {Id}. Applying backoff.", visualizationId);
+                    backoff = NextBackoffSeconds(backoff);
+                    try { await Task.Delay(TimeSpan.FromSeconds(WithJitter(backoff)), ct); } catch { }
+                }
+            }
+        }
+
+        // KPI poller (recalc and broadcast on change). Sentinel optimization can be added later.
+        private async Task KpiLoopAsync(int kpiId, CancellationToken ct)
+        {
+            object? lastValue = null;
+            int backoff = _options.Backoff.BaseSeconds;
+            while (!ct.IsCancellationRequested)
+            {
+                try
+                {
+                    using var scope = _scopeFactory.CreateScope();
+                    var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                    var kpiService = scope.ServiceProvider.GetRequiredService<IKpiService>();
+
+                    var kpi = await db.Kpi.FirstOrDefaultAsync(k => k.Id == kpiId, ct);
+                    if (kpi == null || !kpi.LiveEnabled)
+                    {
+                        await Task.Delay(TimeSpan.FromSeconds(15), ct);
+                        continue;
+                    }
+
+                    // Reuse existing KPI logic
+                    var response = await kpiService.CalculateKpiValueAsync(kpiId, kpi.Username);
+
+                    var newValue = response?.Value;
+                    bool changed = (newValue == null && lastValue != null) ||
+                                   (newValue != null && !newValue.Equals(lastValue));
+
+                    if (changed)
+                    {
+                        await _kpiHub.Clients.Group($"kpi:{kpiId}").SendAsync("kpiUpdate", response, ct);
+                        lastValue = newValue;
+                    }
+
+                    // Interval by module
+                    backoff = _options.Backoff.BaseSeconds; // reset on success
+                    int seconds = string.Equals(kpi.SourceModule, "IM", StringComparison.OrdinalIgnoreCase)
+                        ? _options.ImKpiIntervalSeconds
+                        : _options.EmKpiIntervalSeconds;
+                    await Task.Delay(TimeSpan.FromSeconds(seconds), ct);
+                }
+                catch (OperationCanceledException)
+                {
+                    // normal on stop
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "KPI loop error for {Id}. Applying backoff.", kpiId);
+                    backoff = NextBackoffSeconds(backoff);
+                    try { await Task.Delay(TimeSpan.FromSeconds(WithJitter(backoff)), ct); } catch { }
+                }
+            }
+        }
+
+        private int NextBackoffSeconds(int current)
+        {
+            var next = (int)Math.Ceiling(current * _options.Backoff.Multiplier);
+            if (next < _options.Backoff.BaseSeconds) next = _options.Backoff.BaseSeconds;
+            if (next > _options.Backoff.MaxSeconds) next = _options.Backoff.MaxSeconds;
+            return next;
+        }
+
+        private int WithJitter(int baseSeconds)
+        {
+            var ratio = _options.Backoff.JitterRatio;
+            if (ratio <= 0) return baseSeconds;
+            // Random factor in [1 - ratio, 1 + ratio]
+            var delta = (Random.Shared.NextDouble() * 2 * ratio) - ratio;
+            var result = baseSeconds * (1.0 + delta);
+            return Math.Max(1, (int)Math.Round(result));
+        }
+    }
+}

--- a/OmniMonitor/Server/Live/LiveSubscriptionRegistry.cs
+++ b/OmniMonitor/Server/Live/LiveSubscriptionRegistry.cs
@@ -1,0 +1,72 @@
+using System.Collections.Concurrent;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+namespace OmniMonitor.Server.Live
+{
+    public enum SubscriptionKind { Visualization, Kpi }
+
+    public readonly struct SubscriptionChange
+    {
+        public SubscriptionKind Kind { get; }
+        public int Id { get; }
+        public bool Start { get; }
+        public SubscriptionChange(SubscriptionKind kind, int id, bool start)
+        {
+            Kind = kind;
+            Id = id;
+            Start = start;
+        }
+    }
+
+    public interface ILiveSubscriptionRegistry
+    {
+        Task RegisterVisualizationAsync(int visualizationId);
+        Task UnregisterVisualizationAsync(int visualizationId);
+        Task RegisterKpiAsync(int kpiId);
+        Task UnregisterKpiAsync(int kpiId);
+        ChannelReader<SubscriptionChange> Changes { get; }
+    }
+
+    public class LiveSubscriptionRegistry : ILiveSubscriptionRegistry
+    {
+        private readonly ConcurrentDictionary<(SubscriptionKind Kind, int Id), int> _counts = new();
+        private readonly Channel<SubscriptionChange> _channel = Channel.CreateUnbounded<SubscriptionChange>();
+
+        public ChannelReader<SubscriptionChange> Changes => _channel.Reader;
+
+        private Task RegisterAsync(SubscriptionKind kind, int id)
+        {
+            var key = (kind, id);
+            int newCount = _counts.AddOrUpdate(key, 1, (_, c) => c + 1);
+            if (newCount == 1)
+            {
+                _channel.Writer.TryWrite(new SubscriptionChange(kind, id, true));
+            }
+            return Task.CompletedTask;
+        }
+
+        private Task UnregisterAsync(SubscriptionKind kind, int id)
+        {
+            var key = (kind, id);
+            if (_counts.TryGetValue(key, out int count))
+            {
+                if (count <= 1)
+                {
+                    _counts.TryRemove(key, out _);
+                    _channel.Writer.TryWrite(new SubscriptionChange(kind, id, false));
+                }
+                else
+                {
+                    _counts[key] = count - 1;
+                }
+            }
+            return Task.CompletedTask;
+        }
+
+        public Task RegisterVisualizationAsync(int visualizationId) => RegisterAsync(SubscriptionKind.Visualization, visualizationId);
+        public Task UnregisterVisualizationAsync(int visualizationId) => UnregisterAsync(SubscriptionKind.Visualization, visualizationId);
+        public Task RegisterKpiAsync(int kpiId) => RegisterAsync(SubscriptionKind.Kpi, kpiId);
+        public Task UnregisterKpiAsync(int kpiId) => UnregisterAsync(SubscriptionKind.Kpi, kpiId);
+    }
+}

--- a/OmniMonitor/Server/Program.cs
+++ b/OmniMonitor/Server/Program.cs
@@ -1,12 +1,14 @@
 using System.Text;
 using System.Threading.Tasks;
 
-using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
+using OmniMonitor.Server.Hubs;
 
 using OmniMonitor.Server.Configuration;
 using OmniMonitor.Server.Context;
@@ -23,6 +25,7 @@ builder.Logging.ClearProviders();
 builder.Logging.AddDebug();
 builder.Logging.AddConsole();
 builder.Services.Configure<ApiConfig>(builder.Configuration);
+builder.Services.Configure<OmniMonitor.Server.Configuration.LiveOptions>(builder.Configuration.GetSection("Live"));
 
 if (OperatingSystem.IsWindows())
 {
@@ -51,19 +54,53 @@ builder.Services.AddIdentityCore<User>(options => {
 .AddSignInManager<SignInManager<User>>()
 .AddDefaultTokenProviders();
 
+// For APIs and Hubs, avoid redirects to /Account/Login on 401 challenges (use 401 instead)
+builder.Services.ConfigureApplicationCookie(options =>
+{
+    options.Events.OnRedirectToLogin = context =>
+    {
+        if (context.Request.Path.StartsWithSegments("/hubs") || context.Request.Path.StartsWithSegments("/api"))
+        {
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            return Task.CompletedTask;
+        }
+        context.Response.Redirect(context.RedirectUri);
+        return Task.CompletedTask;
+    };
+});
+
 string corsPolicy = "CORSPolicy";
 builder.Services.AddCors(options =>
 {
-    options.AddPolicy(name: corsPolicy,
-    policy =>
+    options.AddPolicy(name: corsPolicy, policy =>
     {
-        policy.WithOrigins(builder.Configuration.GetSection("CORS").Get<string[]>()!)
-            .AllowAnyHeader()
-            .AllowAnyMethod();
+        var origins = builder.Configuration.GetSection("CORS").Get<string[]>() ?? Array.Empty<string>();
+        if (origins.Contains("*"))
+        {
+            policy
+                .SetIsOriginAllowed(_ => true)
+                .AllowAnyHeader()
+                .AllowAnyMethod();
+            // Do not call AllowCredentials when allowing any origin
+        }
+        else
+        {
+            policy
+                .WithOrigins(origins)
+                .AllowAnyHeader()
+                .AllowAnyMethod()
+                .AllowCredentials();
+        }
     });
 });
 
-builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+// --- JWT AUTHENTICATION SERVICES WITH DEBUGGING ---
+builder.Services.AddAuthentication(options =>
+    {
+        options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+        options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+        options.DefaultScheme = JwtBearerDefaults.AuthenticationScheme;
+    })
     .AddJwtBearer(options =>
     {
 
@@ -82,6 +119,17 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 
         options.Events = new JwtBearerEvents
         {
+            OnMessageReceived = context =>
+            {
+                var accessToken = context.Request.Query["access_token"];
+                var path = context.HttpContext.Request.Path;
+                if (!string.IsNullOrEmpty(accessToken) &&
+                    (path.StartsWithSegments("/hubs/telemetry") || path.StartsWithSegments("/hubs/kpi")))
+                {
+                    context.Token = accessToken;
+                }
+                return Task.CompletedTask;
+            },
             OnTokenValidated = context =>
             {
                 var logger = context.HttpContext.RequestServices.GetRequiredService<ILogger<Program>>();
@@ -192,6 +240,8 @@ builder.Services.AddControllersWithViews()
     });
 builder.Services.AddRazorPages();
 builder.Services.AddScoped<IMailService, MailService>();
+builder.Services.AddSignalR();
+
 builder.Services.AddScoped<ISondaAuthService, SondaAuthService>();
 builder.Services.AddScoped<ISondaIMService, SondaIMService>();
 builder.Services.AddScoped<ISondaUMService, SondaUMService>();
@@ -212,6 +262,8 @@ builder.Services.AddScoped<IKpiService, KpiService>();
 builder.Services.AddScoped<IKpiAMService, KpiAMService>();
 builder.Services.AddScoped<IPasswordHasher<SharedLink>, PasswordHasher<SharedLink>>();
 builder.Services.AddHttpClient();
+builder.Services.AddSingleton<OmniMonitor.Server.Live.ILiveSubscriptionRegistry, OmniMonitor.Server.Live.LiveSubscriptionRegistry>();
+builder.Services.AddHostedService<OmniMonitor.Server.Live.LivePollingHostedService>();
 
 builder.Services.AddHostedService<ScheduledReportWorker>();
 
@@ -362,6 +414,8 @@ app.UseAuthorization();
 
 app.MapRazorPages();
 app.MapControllers();
+app.MapHub<TelemetryHub>("/hubs/telemetry");
+app.MapHub<KpiHub>("/hubs/kpi");
 app.MapFallbackToFile("index.html");
 
 app.Run();

--- a/OmniMonitor/Server/Services/KpiService.cs
+++ b/OmniMonitor/Server/Services/KpiService.cs
@@ -136,6 +136,17 @@ namespace OmniMonitor.Server.Services
                //default:
                //    throw new ArgumentException($"Unsupported SourceModule: {request.SourceModule}");
             }
+            bool requestedLive = request.LiveEnabled ?? false;
+            bool allowLive = requestedLive;
+            if (requestedLive)
+            {
+                string? module = request.SourceModule?.Trim().ToUpperInvariant();
+                if (module == "AM" || module == "UM")
+                {
+                    allowLive = false;
+                }
+            }
+
             var newKpi = new Kpi
             {
                 Name = request.Name,
@@ -150,7 +161,8 @@ namespace OmniMonitor.Server.Services
                 ExtraInfo = request.ExtraInfo,
                 Atributo = string.IsNullOrWhiteSpace(request.Atributo) ? string.Empty : request.Atributo,
                 Username = username ?? string.Empty,
-                Type = request.Type
+                Type = request.Type,
+                LiveEnabled = allowLive
             };
 
             _context.Kpi.Add(newKpi);
@@ -327,6 +339,19 @@ namespace OmniMonitor.Server.Services
             if (request.DefaultColor != null) existingKpi.DefaultColor = request.DefaultColor.Trim();
             if (request.ColorRanges != null) existingKpi.ColorRanges = request.ColorRanges;
             if (request.ExtraInfo != null) existingKpi.ExtraInfo = request.ExtraInfo;
+            if (request.LiveEnabled.HasValue)
+            {
+                bool requestedLive = request.LiveEnabled.Value;
+                string effectiveModule = (request.SourceModule ?? existingKpi.SourceModule)!.Trim().ToUpperInvariant();
+                if (requestedLive && (effectiveModule == "AM" || effectiveModule == "UM"))
+                {
+                    existingKpi.LiveEnabled = false;
+                }
+                else
+                {
+                    existingKpi.LiveEnabled = requestedLive;
+                }
+            }
 
             _context.Kpi.Update(existingKpi);
             await _context.SaveChangesAsync();
@@ -411,6 +436,8 @@ namespace OmniMonitor.Server.Services
                 throw new Exception($"No se pudo calcular el KPI con ID {kpiId}");
 
             response.DatasetName = await GetDatasetNameAsync(kpi.DatasetId);
+            response.LiveEnabled = kpi.LiveEnabled;
+            response.SourceModule = kpi.SourceModule;
             return response;
         }
 
@@ -445,6 +472,8 @@ namespace OmniMonitor.Server.Services
             if (response == null)
                 throw new Exception($"No se pudo calcular el KPI con ID {kpiId}");
 
+            response.LiveEnabled = kpi.LiveEnabled;
+            response.SourceModule = kpi.SourceModule;
             return response;
         }
 

--- a/OmniMonitor/Server/Services/VisualizacionService.cs
+++ b/OmniMonitor/Server/Services/VisualizacionService.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 using Azure.Core;
 using Azure.Identity;
+using System.Text.Json;
 
 using Microsoft.EntityFrameworkCore;
 
@@ -64,6 +65,41 @@ namespace OmniMonitor.Server.Services
             }
 
             await EnsureUniqueNameAsync(request.Nombre, username);
+            bool requestedLive = request.LiveEnabled ?? false;
+            bool allowLive = requestedLive;
+            if (requestedLive && request.Datasets != null && request.Datasets.Any())
+            {
+                foreach (var dsCfg in request.Datasets)
+                {
+                    try
+                    {
+                        using JsonDocument doc = JsonDocument.Parse(dsCfg.JsonDiseño);
+                        if (doc.RootElement.TryGetProperty("Module", out JsonElement modEl))
+                        {
+                            string? module = modEl.GetString()?.Trim();
+                            if (string.Equals(module, "Asset Manager", StringComparison.OrdinalIgnoreCase)
+                                || string.Equals(module, "Urban Monitor", StringComparison.OrdinalIgnoreCase)
+                                || string.Equals(module, "AM", StringComparison.OrdinalIgnoreCase)
+                                || string.Equals(module, "UM", StringComparison.OrdinalIgnoreCase))
+                            {
+                                allowLive = false;
+                                break;
+                            }
+                        }
+                        else
+                        {
+                            allowLive = false;
+                            break;
+                        }
+                    }
+                    catch
+                    {
+                        // On parse error, be conservative: disable live
+                        allowLive = false;
+                        break;
+                    }
+                }
+            }
 
             var nuevaVisualizacion = new Visualizacion
             {
@@ -72,7 +108,8 @@ namespace OmniMonitor.Server.Services
                 FechaDesde = request.FechaDesde,
                 FechaHasta = request.FechaHasta,
                 JsonDesign = request.JsonDiseñoGeneral,
-                Link = request.Link
+                Link = request.Link,
+                LiveEnabled = allowLive
             };
 
             // Añadir los datasets asociados a la visualización

--- a/OmniMonitor/Server/appsettings.json
+++ b/OmniMonitor/Server/appsettings.json
@@ -25,6 +25,17 @@
   "Development": false,
   "EnableHttpsRedirection": true,
   "AllowedHosts": "*",
+  "Live": {
+    "ImChartIntervalSeconds": 3,
+    "ImKpiIntervalSeconds": 5,
+    "EmKpiIntervalSeconds": 15,
+    "Backoff": {
+      "BaseSeconds": 5,
+      "MaxSeconds": 60,
+      "Multiplier": 2.0,
+      "JitterRatio": 0.2
+    }
+  },
   "BaseUrl": {
     "UrlIM": "https://sondasmartplatform.com/internal/IoTMonitor",
     "UrlAM": "https://sondasmartplatform.com/internal/AssetManager",

--- a/OmniMonitor/Shared/Dtos/CreateVisualizacionRequest.cs
+++ b/OmniMonitor/Shared/Dtos/CreateVisualizacionRequest.cs
@@ -18,6 +18,8 @@ namespace OmniMonitor.Shared.Dtos
         public string JsonDiseñoGeneral { get; set; }
 
         public string? Link { get; set; }
+        
+        public bool? LiveEnabled { get; set; }
 
         public List<DatasetConfig> Datasets { get; set; } = new List<DatasetConfig>();
     }

--- a/OmniMonitor/Shared/Dtos/KPI/Kpi.cs
+++ b/OmniMonitor/Shared/Dtos/KPI/Kpi.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
 namespace OmniMonitor.Shared.Dtos
@@ -52,6 +52,8 @@ namespace OmniMonitor.Shared.Dtos
         [JsonPropertyName("type")]
         public int? Type { get; set; }  
 
+        [JsonPropertyName("liveEnabled")]
+        public bool LiveEnabled { get; set; } = false;
 
     }
 

--- a/OmniMonitor/Shared/Dtos/KPI/KpiRequest.cs
+++ b/OmniMonitor/Shared/Dtos/KPI/KpiRequest.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 
 namespace OmniMonitor.Shared.Dtos
 {
@@ -39,6 +39,9 @@ namespace OmniMonitor.Shared.Dtos
 
     [JsonPropertyName("type")]
     public int? Type { get; set; }
+
+        [JsonPropertyName("liveEnabled")]
+        public bool? LiveEnabled { get; set; }
 
     }
 }

--- a/OmniMonitor/Shared/Dtos/KPI/KpiResponse.cs
+++ b/OmniMonitor/Shared/Dtos/KPI/KpiResponse.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 
 namespace OmniMonitor.Shared.Dtos;
 public class KpiResponse
@@ -27,5 +27,11 @@ public class KpiResponse
 
     [JsonPropertyName("datasetName")]
     public string? DatasetName { get; set; }
+    
+    [JsonPropertyName("sourceModule")]
+    public string? SourceModule { get; set; }
+
+    [JsonPropertyName("liveEnabled")]
+    public bool LiveEnabled { get; set; } = false;
 
 }

--- a/OmniMonitor/Shared/Dtos/Visualizacion.cs
+++ b/OmniMonitor/Shared/Dtos/Visualizacion.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
@@ -31,6 +31,7 @@ namespace OmniMonitor.Shared.Dtos
 
         [Column("link")]
         public string? Link { get; set; }
+        public bool LiveEnabled { get; set; } = false;
 
         // Propiedad de navegación para la relación uno a muchos
         public virtual ICollection<GrupoDataset> GrupoDatasets { get; set; } = new List<GrupoDataset>();


### PR DESCRIPTION
## Descripción

- **Objetivo**: Habilitar la creación y administración de tarjetas KPI dentro de los dashboards, manteniendo intacto el flujo existente de visualizaciones.
- **Alcance Backend**: Se agregan relaciones y restricciones para persistir tarjetas KPI asociadas a dashboards. Se actualizan los endpoints para incluir KPI cards al crear/editar/obtener dashboards. Se incluyen migraciones EF Core para claves foráneas y unicidad lógica.
- **Alcance Frontend**: Se incorpora UI para seleccionar y agregar KPIs al dashboard, soporte de reordenamiento y eliminación, y renderizado de tarjetas KPI en modos edición y vista. Se integran notificaciones mediante `SnackService`.
- **Calidad**: Se actualizan/añaden pruebas para mappings y acciones de controlador relacionadas con dashboards que contienen KPI cards.

## Ticket asociado

- **Jira**: 136, 137

## Cómo probar

- **Migraciones**: Aplicar las migraciones de base de datos (EF Core) antes de iniciar.
- **Arranque**: Levantar API y cliente en modo Development.
- **Crear dashboard**: Crear un dashboard nuevo desde la UI.
- **Agregar tarjetas**: 
  - Agregar una tarjeta KPI.
  - Agregar una visualización tradicional.
- **Reordenar y guardar**: Reordenar tarjetas y guardar el dashboard sin errores.
- **Verificar persistencia**: Recargar la página y confirmar que las tarjetas (KPI y visualizaciones) se cargan en el orden guardado.
- **Editar y eliminar**: Entrar en modo edición, eliminar una tarjeta KPI y guardar. Confirmar que se persiste.
- **Regresiones**: Validar que el flujo de agregar/editar/eliminar visualizaciones tradicionales sigue funcionando.
- **Pruebas automatizadas**: Ejecutar los tests locales y verificar que resulten en verde.

## Checklist

- [x] Código compilado sin errores
- [x] Tests locales ejecutados y aprobados
- [x] Commit y branch nombrados con ticket correspondiente
- [ ] PR revisado y aprobado por los reviewers necesarios
